### PR TITLE
Greenkeeper SVG path

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # futil
-[![Greenkeeper badge](https://badges.greenkeeper.io/smartprocure/futil.svg)](https://greenkeeper.io/)
+[![Greenkeeper badge](https://badges.greenkeeper.io/smartprocure/futil-js.svg)](https://greenkeeper.io/)
 [![npm version](https://badge.fury.io/js/futil-js.svg)](https://badge.fury.io/js/futil-js)
 ![dependencies](https://david-dm.org/smartprocure/futil-js.svg)
 [![Code Climate](https://codeclimate.com/github/smartprocure/futil-js/badges/gpa.svg)](https://codeclimate.com/github/smartprocure/futil-js)


### PR DESCRIPTION
The svg path was wrong, however the correct path seems to show that it's disabled. Proof:

![https://badges.greenkeeper.io/smartprocure/futil-js.svg](https://badges.greenkeeper.io/smartprocure/futil-js.svg)