### PR TITLE
y-combinator for deepMap

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -21,13 +21,15 @@ export const flowMap = (...fns) => _.map(_.flow(...fns))
 
 // Algebras
 // --------
-const isTraversable = x => _.isArray(x) || _.isPlainObject(x)
+// y-combinator, as in: http://kestas.kuliukas.com/YCombinatorExplained
+// f is the function that returns the function we want to make recursive
+// n indicates the next call of f
+export const y = f => (n => n(n))(n => f(x => n(n)(x))) // eslint-disable-line lodash-fp/no-extraneous-function-wrapping
 // A generic map that works for plain objects and arrays
-export const map = _.curry((f, x) => (_.isArray(x) ? _.map : _.mapValues)(f, x))
+export const map = _.curry((f, x) => (_.isArray(x) && _.map(f, x)) || (_.isPlainObject(x) && _.mapValues(f, x)) || x)
 // Map for any recursive algebraic data structure
 // defaults in multidimensional arrays and recursive plain objects
-export const deepMap = _.curry((fn, obj, _map = map, is = isTraversable) =>
-    _map(e => is(e) ? deepMap(fn, fn(e), _map, is) : e, obj))
+export const deepMap = y(r => f => map(e => r(f)(f(e))))
 
 // Misc
 // ----

--- a/test/algebras.spec.js
+++ b/test/algebras.spec.js
@@ -10,7 +10,7 @@ describe('Algebras', () => {
 
         const arrBackup = _.cloneDeep(arr)
 
-        const arrMutated = f.deepMap(e => e.concat(101), arr)
+        const arrMutated = f.deepMap(e => _.isArray(e) ? e.concat(101) : e)(arr)
 
         // Checking immutability
         expect(arr).to.eql(arrBackup)
@@ -119,28 +119,5 @@ describe('Algebras', () => {
                 }
             }
         })
-    })
-
-    it('deepMap Sets', () => {
-        const setRoot = new Set()
-        const set1 = new Set()
-        const set2 = new Set()
-        setRoot.add(0)
-        setRoot.add(set1)
-        set1.add(1)
-        set1.add(set2)
-        set2.add(2)
-
-        const map = (f, s) => {
-            for (let v of Array.from(s.values())) {
-                s.delete(v)
-                s.add(f(v))
-            }
-            return s
-        }
-
-        const setMutated = f.deepMap(s => s.add(101), setRoot, map, _.isSet)
-
-        expect(JSON.stringify(setMutated)).to.equal('[0,[1,[2,101],101]]')
     })
 })


### PR DESCRIPTION
This PR isn't compatible with https://github.com/smartprocure/futil-js/pull/52 since it doesn't run at the root level, to make it run at the root level, it would be: `const deepMap = y(r => f => o => map(e => r(f)(e), f(o)))`.

Visual comparision of both deepMaps:

```
export const deepMap = f => o => map(deepMap(f), f(o))
export const deepMap = y(r => f => o => map(e => r(f)(e), f(o)))
```

I personally don't think the y-combinator is necessary or useful for us in this scenario :/ unless it could be written in a better way that I'm not seeing.

One friend of mine made a js-perf of the y-combinator for a fibonacci function and spotted a huge performance decrement (vs normal recursion): https://jsperf.com/fib-in-many-ways