### PR TITLE
v1.11.1 thanks to Greenkeeper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-﻿# 1.11.0
+# 1.11.1
+- Greenkeeper udpated the babel-loader and danger-js
+
+# 1.11.0
 - Added `cycle`
 
 # 1.10.2

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "futil-js",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "description": "F(unctional) util(ities). Resistance is futile.",
   "main": "lib/futil-js.js",
   "scripts": {


### PR DESCRIPTION
Greenkeeper updated [babel-loader](https://github.com/smartprocure/futil-js/pull/81) and [danger-js](https://github.com/smartprocure/futil-js/pull/80) in recently merged pull requests.