### PR TITLE
`unflattenObject` and `mapProp` deprecation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.17.0
+Added `unflattenObject` and a deprecation warning about `mapProp` in favor of lodash `_.update`
+
 # 1.16.0
 Added `aspect` and the reusable examples on `aspects` (`logs`, `errors`, `status`, and `concurrency`), as well as `throws`
 

--- a/README.md
+++ b/README.md
@@ -150,9 +150,13 @@ Flatten an object with the paths for keys.
 
 Example: `{ a: { b: { c: 1 } } } => { 'a.b.c' : 1 }`.
 
+### unflattenObject
+Unlatten an object with the paths for keys.
+
+Example: `{ 'a.b.c' : 1 } => { a: { b: { c: 1 } } }`.
 
 ### mapProp
-Applies a map function at a specific path
+_Deprecated in favor of lodash `update`_ Applies a map function at a specific path
 
 Example: `mapProp(double, 'a', {a: 2, b: 1}) -> {a: 4, b: 1}`.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "futil-js",
-  "version": "1.16.0",
+  "version": "1.17.0",
   "description": "F(unctional) util(ities). Resistance is futile.",
   "main": "lib/futil-js.js",
   "scripts": {

--- a/src/object.js
+++ b/src/object.js
@@ -45,6 +45,9 @@ export const isFlatObject = overNone([_.isPlainObject, _.isArray])
 export const flattenObject = (input, paths) => reduce((output, value, key) =>
   _.merge(output, (isFlatObject(value) ? singleObjectR : flattenObject)(value, dotJoin([paths, key]))), {}, input)
 
+// { 'a.b.c' : 1 } => { a: { b: { c: 1 } } }
+export const unflattenObject = x => _.zipObjectDeep(_.keys(x), _.values(x))
+
 // Returns true if object keys are only elements from signature list (but does not require all signature keys to be present)
 export const matchesSignature = _.curry((signature, value) =>
   _.isObject(value) && !_.difference(_.keys(value), signature).length)

--- a/test/objects.spec.js
+++ b/test/objects.spec.js
@@ -89,6 +89,17 @@ describe('Object Functions', () => {
       'a.b.c': 1
     })
   })
+  it('unflattenObject', () => {
+    expect(f.unflattenObject({
+      'a.b.c': 1
+    })).to.deep.equal({
+      a: {
+        b: {
+          c: 1
+        }
+      }
+    })
+  })
   it('renameProperty', () => {
     const o = { a: 1 }
     const newO = f.renameProperty('a', 'b', o)


### PR DESCRIPTION
Add `unflattenObject` and warn about `mapProp` deprecation in favor of lodash `_.update`