### PR TITLE
add babel-polyfill now that we are using async for aspects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.17.1
+Include babel-polyfill in webpack build now that aspects have `async` functions
+
 # 1.17.0
 Added `unflattenObject` and a deprecation warning about `mapProp` in favor of lodash `_.update`
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "futil-js",
-  "version": "1.17.0",
+  "version": "1.17.1",
   "description": "F(unctional) util(ities). Resistance is futile.",
   "main": "lib/futil-js.js",
   "scripts": {
@@ -17,6 +17,7 @@
   "author": "Samuel Greene <sgreene@smartprocure.us>",
   "license": "MIT",
   "dependencies": {
+    "babel-polyfill": "^6.23.0",
     "lodash": "^4.17.4"
   },
   "babel": {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,7 +4,7 @@ var outputFile = libraryName + '.js'
 
 module.exports = {
   devtool: 'source-map',
-  entry: path.join(__dirname, 'src/index.js'),
+  entry: ['babel-polyfill', path.join(__dirname, 'src/index.js')],
   output: {
     path: path.join(__dirname, 'lib'),
     filename: outputFile,


### PR DESCRIPTION
This is to avoid regeneratorRuntime errors for consumers