### PR TITLE
convert aspect async to promises and rip out babel-polyfill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.17.3
+Convert aspect to Promise instead of async/await and rip out babel-polyfill
+
 # 1.17.2
 Pass original params to onError and after
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "futil-js",
-  "version": "1.17.2",
+  "version": "1.17.3",
   "description": "F(unctional) util(ities). Resistance is futile.",
   "main": "lib/futil-js.js",
   "scripts": {
@@ -33,6 +33,7 @@
     "babel-loader": "^7.0.0",
     "babel-preset-latest": "^6.22.0",
     "chai": "^3.5.0",
+    "chai-as-promised": "^6.0.0",
     "chokidar": "^1.6.1",
     "chokidar-cli": "^1.2.0",
     "codacy-coverage": "^2.0.1",

--- a/src/aspect.js
+++ b/src/aspect.js
@@ -12,15 +12,14 @@ export let aspect = ({
 }) => f => {
   let {state = {}} = f
   init(state)
-  let result = async (...args) => {
-    try {
-      before(args, state)
-      let result = await f(...args)
-      after(result, state, args)
-      return result
-    } catch (e) {
-      return onError(e, state, args)
-    }
+  let result = (...args) => {
+    before(args, state)
+    return Promise.resolve().then(() => {
+      return Promise.resolve(f(...args)).then(result => {
+        after(result, state, args)
+        return result
+      })
+    }).catch(e => onError(e, state, args))
   }
   result.state = state
   return result

--- a/test/aspect.spec.js
+++ b/test/aspect.spec.js
@@ -1,7 +1,9 @@
-import chai from 'chai'
-import {aspects} from '../src'
 import _ from 'lodash/fp'
+import chai from 'chai'
+import chaiAsPromised from 'chai-as-promised'
+import {aspects, aspect} from '../src'
 
+chai.use(chaiAsPromised);
 chai.expect()
 const expect = chai.expect
 
@@ -41,5 +43,16 @@ describe('Aspect Functions', () => {
     expect(g.state.errors[1]).to.deep.equal(Error({
       message: 'Concurrent Runs Not Allowed'
     }))
+  })
+  it('should support throwing in onError', async () => {
+    let ThrowHi = aspect({
+      onError: e => {
+        throw Error('hi from aspect')
+      }
+    })
+    let throwsHi = ThrowHi(() => {
+      throw Error('Not hi')
+    })
+    expect(throwsHi()).to.be.rejectedWith(Error('hi from aspect'))
   })
 })

--- a/test/aspect.spec.js
+++ b/test/aspect.spec.js
@@ -3,7 +3,7 @@ import chai from 'chai'
 import chaiAsPromised from 'chai-as-promised'
 import {aspects, aspect} from '../src'
 
-chai.use(chaiAsPromised);
+chai.use(chaiAsPromised)
 chai.expect()
 const expect = chai.expect
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,7 +4,7 @@ var outputFile = libraryName + '.js'
 
 module.exports = {
   devtool: 'source-map',
-  entry: ['babel-polyfill', path.join(__dirname, 'src/index.js')],
+  entry: path.join(__dirname, 'src/index.js'),
   output: {
     path: path.join(__dirname, 'lib'),
     filename: outputFile,


### PR DESCRIPTION
`babel-polyfill` was required to use async/await here with an app using create-react-app, but we can't have it loaded twice. `futil-js` can just the promise api for now