### PR TITLE
Add support async before and after to aspect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.21.0
+`aspect` now supports async `before`, `after`, and `onError`
+
 # 1.20.0
 Add `findApply`, `isNotNil`, `exists`, `unlessExists`, `unlessTruth`, `getOrReturn`, `alias`, `cascade`, `cascadeIn`, `cascadeKey`, `isMultiple`, `append`, `composeApply`, `comply`
 

--- a/README.md
+++ b/README.md
@@ -365,8 +365,8 @@ Options supports the following parameters:
 | Name | Description |
 | --- | --- |
 | `init: (state) -> ()` | A function for setting any inital state requirements. Should mutate the shared state object. |
-| `after: (result, state, params) -> ()` | Runs after the wrapped function executes and recieves the shared state and the result of the function. |
-| `before: (params, state) -> ()` | Runs before the wrapped function executes and receves the shared state and the params passed to the wrapped function. |
+| `after: (result, state, params) -> ()` | Runs after the wrapped function executes and recieves the shared state and the result of the function. Can be async. |
+| `before: (params, state) -> ()` | Runs before the wrapped function executes and receves the shared state and the params passed to the wrapped function. Can be async. |
 | `onError: (error, state, params) -> ()` | Runs if the wrapped function throws an error. If you don't throw inside this, it will swallow any errors that happen. |
 
 Example Usage:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "futil-js",
-  "version": "1.20.0",
+  "version": "1.21.0",
   "description": "F(unctional) util(ities). Resistance is futile.",
   "main": "lib/futil-js.js",
   "scripts": {

--- a/src/aspect.js
+++ b/src/aspect.js
@@ -16,8 +16,9 @@ export let aspect = ({
     let result
     return Promise.resolve()
       .then(() => before(args, state))
-      .then(() => {
-        result = f(...args)
+      .then(() => f(...args))
+      .then(r => {
+        result = r
       })
       .then(() => after(result, state, args))
       .then(() => result)

--- a/src/aspect.js
+++ b/src/aspect.js
@@ -3,7 +3,6 @@ import {defaultsOn} from './conversion'
 import {throws} from './index'
 
 // Core
-// Core
 export let aspect = ({
   init = _.noop,
   after = _.noop,

--- a/src/aspect.js
+++ b/src/aspect.js
@@ -3,6 +3,7 @@ import {defaultsOn} from './conversion'
 import {throws} from './index'
 
 // Core
+// Core
 export let aspect = ({
   init = _.noop,
   after = _.noop,
@@ -13,13 +14,15 @@ export let aspect = ({
   let {state = {}} = f
   init(state)
   let result = (...args) => {
-    before(args, state)
-    return Promise.resolve().then(() => {
-      return Promise.resolve(f(...args)).then(result => {
-        after(result, state, args)
-        return result
+    let result
+    return Promise.resolve()
+      .then(() => before(args, state))
+      .then(() => {
+        result = f(...args)
       })
-    }).catch(e => onError(e, state, args))
+      .then(() => after(result, state, args))
+      .then(() => result)
+      .catch(e => onError(e, state, args))
   }
   result.state = state
   return result


### PR DESCRIPTION
The previous implementation assumed that before/after were synchronous and also didn't throw