### PR TITLE
T, S and P combinators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-﻿# 1.24.0
+﻿# 1.25.0
+Added the combinators  T (callWith), S (ap) and P (joinWith).
+
+# 1.24.0
 Added `trimStrings`, and our new shiny logo on the README thanks to @giulianok
 
 # 1.23.0

--- a/README.md
+++ b/README.md
@@ -43,9 +43,19 @@ The syntax: `import f from futil-js` is not currently supported.
 ### converge
 http://ramdajs.com/docs/#converge
 
+### callWith
+`x => f => f(x)` the T combinator.
+
+### ap
+`f => g => x => f(x)(g(x))` the S combinator.
+
 ### comply (alias: composeApply)
-`(f, g) => x => f(g(x))(x)`
-A combinator that combines compose and apply
+`f => g => x => f(g(x))(x)`
+A combinator that combines compose (B) and apply (A)
+
+### joinWith
+`f => g => x => y => f(g(x))(g(y))` the P combinator. Known as the
+`psi` bird, or as the operator `on` in Haskell.
 
 ## Logic
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "futil-js",
-  "version": "1.24.0",
+  "version": "1.25.0",
   "description": "F(unctional) util(ities). Resistance is futile.",
   "main": "lib/futil-js.js",
   "scripts": {
@@ -39,7 +39,7 @@
     "codacy-coverage": "^2.0.1",
     "coveralls": "^2.11.16",
     "danger": "^0.17.0",
-    "eslint": "^4.1.0",
+    "eslint": "^3.19.0",
     "eslint-config-standard": "^10.0.0",
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-lodash-fp": "^2.0.1",

--- a/src/function.js
+++ b/src/function.js
@@ -12,5 +12,28 @@ export const boundMethod = (method, object) => object[method].bind(object)
 // http://ramdajs.com/docs/#converge
 export const converge = (converger, branches) => (...args) => converger(_.over(branches)(...args))
 
-export let composeApply = (f, g) => x => f(g(x))(x)
+// From: https://gist.github.com/Avaq/1f0636ec5c8d6aed2e45
+
+// I = x => x is _.identity
+// K = x => y => x _.constant
+// A = f => x => f(x) called apply or call. We can use _.flow(f)(x)
+// W = f => x => f(x)(x) _.join
+// C = f => y => x => f(x)(y) called flip. We can use _ to flip functions: _.map(_, [])
+// B = f => g => x => f(g(x)) we have _.flow and _.flowRight
+
+// T = x => f => f(x) called thrush
+export let callWith = _.curry((f, g) => g(f))
+
+// S = f => g => x => f(x)(g(x))
+export let ap = _.curry((f, g, x) => f(x)(g(x)))
+
+// BA = f => g => x => f(g(x))(x) = A(B(f, g), x)
+export let composeApply = _.curry((f, g, x) => f(g(x))(x))
 export let comply = composeApply
+
+// P = f => g => x => y => f(g(x))(g(y)) also called `on`
+export let joinWith = _.curry((f, g, x, y) => f(g(x))(g(y)))
+
+// Y combinator. We have recursion in JavaScript
+// so I'm leaving this just for documentation purposes.
+// let Y = f => (g => g(g))(g => f(x => g(g)(x)))

--- a/test/combinators.spec.js
+++ b/test/combinators.spec.js
@@ -1,0 +1,26 @@
+import chai from 'chai'
+import * as f from '../src/'
+import _ from 'lodash/fp'
+chai.expect()
+const expect = chai.expect
+
+describe('Algebras', () => {
+  it('callWith', () => {
+    expect(f.callWith('hello world', _.toUpper)).to.equal('HELLO WORLD')
+    expect(f.callWith('hello world')(_.flow(_.toUpper, _.split(' '), _.join(', ')))).to.equal('HELLO, WORLD')
+    expect(f.callWith(_.toUpper)(_.map)(['Hello', 'world'])).to.deep.equal(['HELLO', 'WORLD'])
+  })
+  it('ap', () => {
+    let x = {a: ' hello', b: 'world ', c: 123}
+    expect(f.ap(f.extendOn, f.trimStrings, x)).to.deep.equal({a: 'hello', b: 'world', c: 123})
+    expect(x).to.deep.equal({a: 'hello', b: 'world', c: 123})
+  })
+  it('comply', () => {
+    // (5 * 2) +  5
+    expect(f.comply(f.append, x => x * 2)(5)).to.equal(15)
+  })
+  it('joinWith', () => {
+    expect(f.joinWith(_.merge, f.trimStrings, {a: ' hello'}, {b: 'world '})).to.deep.equal({a: 'hello', b: 'world'})
+    expect(f.joinWith(_.concat, _.reverse, [1, 2, 3], [4, 5, 6])).to.deep.equal([3, 2, 1, 6, 5, 4])
+  })
+})

--- a/test/misc.spec.js
+++ b/test/misc.spec.js
@@ -22,10 +22,6 @@ describe('Basic Functions', () => {
     expect(obj.greet.call({ name: 'John Henry' })).to.equal('Welcome, John Henry')
     expect(f.boundMethod('greet', obj)()).to.equal('Welcome, Wade Watts')
   })
-  it('comply', () => {
-    // (5 * 2) +  5
-    expect(f.comply(f.append, x => x * 2)(5)).to.equal(15)
-  })
 })
 
 describe('String Functions', () => {


### PR DESCRIPTION
Added the combinators  T (callWith), S (ap) y P (psi) in a new file, called `combinators.js`, moved the BA combinator (comply) to the list of combinators.