### PR TITLE
Prevent IE from breaking on deprecate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.29.3
+- Fix IE 11 erroring when using a deprecated function
+
 # 1.29.2
 - Add missing stack reference to `deprecate`.
 - Fix internal usage of deprecated functions.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "futil-js",
-  "version": "1.29.2",
+  "version": "1.29.3",
   "description": "F(unctional) util(ities). Resistance is futile.",
   "main": "lib/futil-js.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "chokidar-cli": "^1.2.0",
     "codacy-coverage": "^2.0.1",
     "coveralls": "^2.11.16",
-    "duti": "^0.3.0",
+    "duti": "^0.3.3",
     "eslint": "4.1.0",
     "eslint-config-standard": "^10.0.0",
     "eslint-plugin-import": "^2.2.0",

--- a/src/aspect.js
+++ b/src/aspect.js
@@ -142,7 +142,7 @@ let command = (extend, timeout) => _.flow(
 
 let deprecate = (subject, version, alternative) => aspectSync({
   before: () =>
-    console.warn(`\`${subject}\` is deprecated${version ? ` as of ${version}` : ''}${alternative ? ` in favor of \`${alternative}\`` : ''} ${_.trim(Error().stack.split('\n')[3])}`)
+    console.warn(`\`${subject}\` is deprecated${version ? ` as of ${version}` : ''}${alternative ? ` in favor of \`${alternative}\`` : ''} ${_.trim((Error().stack || '').split('\n')[3])}`)
 })
 
 export let aspects = {


### PR DESCRIPTION
IE would break if using a deprecated futil function—this fixes that.