### PR TITLE
flattenObject fix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ notify:
 jobs:
   build:
     docker:
-      - image: circleci/node:latest
+      - image: circleci/node:8.7
     steps:
       - checkout
       - restore_cache:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
-﻿# 1.33.2
+﻿# 1.34.0
+- Fixed flattenObject and diffArray to properly say the paths of
+  arrays with only one object, by making them use a new function:
+  `dotJoinWith`, which is like `dotJoin` but allows you to provide a
+  function to select which elements to filter by.
+
+# 1.33.2
 - Add cross browsers testing support with `karma + webpack + saucelabs`
 - Use babel-preset-latest instead of babel-preset-env
 - Fixed unstable tests for mobile Safari browsers.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<img src='https://user-images.githubusercontent.com/8062245/28718527-796382ac-7374-11e7-98a3-9791223042a4.png' width='200' alt='futil-js'>
+﻿<img src='https://user-images.githubusercontent.com/8062245/28718527-796382ac-7374-11e7-98a3-9791223042a4.png' width='200' alt='futil-js'>
 
 ---
 
@@ -130,6 +130,10 @@ Any method with uncapped iteratee arguments will use the `Indexed` convention.
 ### dotJoin
 `data:array -> result:string` Compacts and joins an array with '.'
 
+### dotJoinWith
+`filterFunction -> data:array -> result:string` Compacts an array by
+the provided function, then joins it with '.'
+ 
 ### repeated
 `data:array -> result:array` Returns an array of elements that are repeated in the array.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "futil-js",
-  "version": "1.33.2",
+  "version": "1.34.0",
   "description": "F(unctional) util(ities). Resistance is futile.",
   "main": "lib/futil-js.js",
   "scripts": {

--- a/src/array.js
+++ b/src/array.js
@@ -13,6 +13,7 @@ let last = _.takeRight(1)
 // ------
 export const compactJoin = _.curry((join, x) => _.compact(x).join(join))
 export const dotJoin = compactJoin('.')
+export const dotJoinWith = fn => x => _.filter(fn, x).join('.')
 export const repeated = _.flow(
   _.groupBy(e => e),
   _.filter(e => e.length > 1),

--- a/src/object.js
+++ b/src/object.js
@@ -1,5 +1,5 @@
 import _ from 'lodash/fp'
-import { dotJoin } from './array'
+import { dotJoinWith } from './array'
 import { overNone } from './logic'
 import {
   reduceIndexed,
@@ -58,7 +58,7 @@ export const flattenObject = (input, paths) =>
         output,
         (isFlatObject(value) ? singleObjectR : flattenObject)(
           value,
-          dotJoin([paths, key])
+          dotJoinWith(x => x === 0 || x)([paths, key])
         )
       ),
     {},

--- a/src/object.js
+++ b/src/object.js
@@ -1,6 +1,7 @@
 import _ from 'lodash/fp'
 import { dotJoinWith } from './array'
 import { overNone } from './logic'
+import { isNotNil } from './lang'
 import {
   reduceIndexed,
   pickIn,
@@ -58,7 +59,7 @@ export const flattenObject = (input, paths) =>
         output,
         (isFlatObject(value) ? singleObjectR : flattenObject)(
           value,
-          dotJoinWith(x => x === 0 || x)([paths, key])
+          dotJoinWith(isNotNil)([paths, key])
         )
       ),
     {},

--- a/test/objects.spec.js
+++ b/test/objects.spec.js
@@ -410,6 +410,7 @@ describe('Object Functions', () => {
     expect(
       f.diffArray(
         {
+          z: {},
           x: 1,
           a: 3,
           d: {
@@ -421,6 +422,7 @@ describe('Object Functions', () => {
           collection2: [{ a: 1, b: 2 }],
         },
         {
+          z: { zz: 1 },
           a: 1,
           b: 2,
           c: 3,
@@ -465,6 +467,11 @@ describe('Object Functions', () => {
         field: 'collection2.0.b',
         from: 2,
         to: undefined,
+      },
+      {
+        field: 'z.zz',
+        from: undefined,
+        to: 1,
       },
       {
         field: 'b',

--- a/test/objects.spec.js
+++ b/test/objects.spec.js
@@ -110,13 +110,17 @@ describe('Object Functions', () => {
       'a.b.c': 1,
     })
     expect(
-      f.flattenObject([{
-        a: {
-          b: [{
-            c: 1,
-          }],
+      f.flattenObject([
+        {
+          a: {
+            b: [
+              {
+                c: 1,
+              },
+            ],
+          },
         },
-      }])
+      ])
     ).to.deep.equal({
       '0.a.b.0.c': 1,
     })

--- a/test/objects.spec.js
+++ b/test/objects.spec.js
@@ -109,6 +109,17 @@ describe('Object Functions', () => {
     ).to.deep.equal({
       'a.b.c': 1,
     })
+    expect(
+      f.flattenObject([{
+        a: {
+          b: [{
+            c: 1,
+          }],
+        },
+      }])
+    ).to.deep.equal({
+      '0.a.b.0.c': 1,
+    })
   })
   it('unflattenObject', () => {
     expect(
@@ -437,17 +448,17 @@ describe('Object Functions', () => {
         to: undefined,
       },
       {
-        field: 'collection1.b',
+        field: 'collection1.0.b',
         from: 2,
         to: undefined,
       },
       {
-        field: 'collection2.a',
+        field: 'collection2.0.a',
         from: 1,
         to: undefined,
       },
       {
-        field: 'collection2.b',
+        field: 'collection2.0.b',
         from: 2,
         to: undefined,
       },


### PR DESCRIPTION
flattenObject is flattening empty arrays in the wrong way, the result of
it is that empty arrays appear to be simple objects. The reason this is
happening is because we're trusting on `dotJoin`, which uses `compact`,
which by definition removes zeroes from the array.

My solution is simply to add another `dotJoin` that allows zeroes. I'm
naming it `dotJoinWith`, since it accepts a function that will be used
to select how to filter the array.