### PR TITLE
Ignoring npm publish errors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,5 +42,5 @@ jobs:
           command: |
             if [ "${CIRCLE_BRANCH}" == "master" ]; then
               echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
-              npm publish
+              npm publish || true
             fi


### PR DESCRIPTION
So that we can merge greenkeeper pull requests for dev dependencies into master without having to upgrade.