### PR TITLE
Add matches some

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
-﻿
+# 1.44.0
+- Added `matchesSome`
+
 # 1.43.4
 - Fixed issue with `postings` when a regex lacking the `g` flag is passed
 - improvements to README.md

--- a/README.md
+++ b/README.md
@@ -224,6 +224,10 @@ Checks if an object's property is equal to a value.
 Returns true if object keys are only elements from signature list. (but does not require all signature keys to be present)
 
 
+### matchesSome
+Similar to `_.matches`, except it returns true if 1 or more object properties match instead of all of them. See https://github.com/lodash/lodash/issues/3713.
+
+
 ### pickInto
 *TODO*
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "futil-js",
-  "version": "1.43.4",
+  "version": "1.44.0",
   "description": "F(unctional) util(ities). Resistance is futile.",
   "main": "lib/futil-js.js",
   "scripts": {

--- a/src/object.js
+++ b/src/object.js
@@ -75,6 +75,9 @@ export const matchesSignature = _.curry(
     _.isObject(value) && !_.difference(_.keys(value), signature).length
 )
 
+// `_.matches` that returns true if one or more of the conditions match instead of all
+export const matchesSome = _.flow(chunkObject, _.map(_.matches), _.overSome)
+
 // Checks if a property deep in a given item equals to a given value
 export const compareDeep = _.curry(
   (path, item, value) => _.get(path, item) === value

--- a/test/objects.spec.js
+++ b/test/objects.spec.js
@@ -160,10 +160,18 @@ describe('Object Functions', () => {
     expect(f.matchesSignature(['a', 'b'], { a: undefined })).to.equal(true)
   })
   it('matchesSome', () => {
-    expect(f.matchesSome({ a: 1, b: 2 })({ a: 1, b: 2, c: 3 })).to.deep.equal(true)
-    expect(f.matchesSome({ a: 1, b: 20 })( {a: 1, b: 2, c: 3 })).to.deep.equal(true)
-    expect(f.matchesSome({ a: 10, b: 2 })({ a: 1, b: 2, c: 3 })).to.deep.equal(true)
-    expect(f.matchesSome({ a: 10, b: 20 })({ a: 1, b: 2, c: 3 })).to.deep.equal(false)
+    expect(f.matchesSome({ a: 1, b: 2 })({ a: 1, b: 2, c: 3 })).to.deep.equal(
+      true
+    )
+    expect(f.matchesSome({ a: 1, b: 20 })({ a: 1, b: 2, c: 3 })).to.deep.equal(
+      true
+    )
+    expect(f.matchesSome({ a: 10, b: 2 })({ a: 1, b: 2, c: 3 })).to.deep.equal(
+      true
+    )
+    expect(f.matchesSome({ a: 10, b: 20 })({ a: 1, b: 2, c: 3 })).to.deep.equal(
+      false
+    )
   })
   it('compareDeep', () => {
     const o = { a: { b: { c: 1 } } }

--- a/test/objects.spec.js
+++ b/test/objects.spec.js
@@ -159,6 +159,12 @@ describe('Object Functions', () => {
     )
     expect(f.matchesSignature(['a', 'b'], { a: undefined })).to.equal(true)
   })
+  it('matchesSome', () => {
+    expect(f.matchesSome({ a: 1, b: 2 })({ a: 1, b: 2, c: 3 })).to.deep.equal(true)
+    expect(f.matchesSome({ a: 1, b: 20 })( {a: 1, b: 2, c: 3 })).to.deep.equal(true)
+    expect(f.matchesSome({ a: 10, b: 2 })({ a: 1, b: 2, c: 3 })).to.deep.equal(true)
+    expect(f.matchesSome({ a: 10, b: 20 })({ a: 1, b: 2, c: 3 })).to.deep.equal(false)
+  })
   it('compareDeep', () => {
     const o = { a: { b: { c: 1 } } }
     expect(f.compareDeep('a.b.c', o, 1)).to.deep.equal(true)


### PR DESCRIPTION
Similar to `_.matches`, except it returns true if 1 or more object properties match instead of all of them. See https://github.com/lodash/lodash/issues/3713.