### PR TITLE
Inject package version during the build and expose it at runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.47.0
+- Added VERSION property to the library's API
+
 # 1.46.0
   - Deprecated `mapProps` in favor of lodash _.update
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "webpack",
     "danger": "duti",
-    "test": "babel-node ./node_modules/mocha/bin/_mocha",
+    "test": "babel-node ./node_modules/mocha/bin/_mocha --require ./test/init.js",
     "test:watch": "chokidar 'src/*.js' 'test/*.js' -c 'npm t'",
     "browser": "TEST_ENV=browser karma start karma.conf.js",
     "browser:local": "karma start karma.conf.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "futil-js",
-  "version": "1.46.0",
+  "version": "1.47.0",
   "description": "F(unctional) util(ities). Resistance is futile.",
   "main": "lib/futil-js.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,5 @@
+/* global __VERSION__ */
+
 import _ from 'lodash/fp'
 
 export * from './conversion'
@@ -16,3 +18,7 @@ export * from './tree'
 // Math
 // ----
 export const greaterThanOne = _.lt(1)
+
+// Version
+// ----
+export const VERSION = __VERSION__

--- a/test/init.js
+++ b/test/init.js
@@ -1,0 +1,1 @@
+global.__VERSION__ = '1.0.0'

--- a/test/misc.spec.js
+++ b/test/misc.spec.js
@@ -37,3 +37,9 @@ describe('Math Functions', () => {
     }
   })
 })
+
+describe('Version Injection', () => {
+  it('should export the VERSION', () => {
+    expect(f.VERSION).to.equal('1.0.0')
+  })
+})

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,8 @@
 var path = require('path')
-var libraryName = require('./package.json').name
+var webpack = require('webpack')
+var packageMetadata = require('./package.json')
+var libraryName = packageMetadata.name
+var libraryVersion = packageMetadata.version
 var outputFile = libraryName + '.js'
 
 module.exports = {
@@ -27,4 +30,7 @@ module.exports = {
   externals: {
     'lodash/fp': 'lodash/fp',
   },
+  plugins: [
+    new webpack.DefinePlugin({ __VERSION__: JSON.stringify(libraryVersion) }),
+  ],
 }


### PR DESCRIPTION
closes #146 

I decided to use the built-in Define plugin in Webpack as it doesn't add any external dependency and is just enough for the desired behaviour.

It simply defines a macro (picked __VERSION__ to minimise the risk of name collision in the future) with the version found in `package.json` at build time. That macro is then exported by the package's index as a named constant `VERSION`.

I had to slightly tweak the test script to require a file before the tests run that initialises a mock `__VERSION__` so we can assert that the correct value is being exported.