### PR TITLE
Remove unused variable making ESLint checks pass

### DIFF
--- a/test/objects.spec.js
+++ b/test/objects.spec.js
@@ -1,5 +1,4 @@
 import chai from 'chai'
-import _ from 'lodash'
 import * as f from '../src'
 
 chai.expect()


### PR DESCRIPTION
ESLint seems to be complaining about that line:
`2:8  error  '_' is defined but never used  no-unused-vars`

making the CI fail on the lint step