### PR TITLE
toSentence & intersperse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # 1.55.0
-- Added intercalateWith, intercalate, intercalateGrammar and toSentence.
+- Added intersperseWith, intersperse, intersperseGrammar and toSentence.
 
 # 1.54.0
 - Add `domLens` functions: 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ﻿# 1.54.0
-- Added toSentenceWith and toSentence.
+- Added intercalateWith, intercalate, intercalateGrammar and toSentence.
 
 # 1.53.0
 - Add `moveIndex`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ﻿# 1.55.0
-- Added intersperse, differentLast and toSentence.
+- Added intersperse, differentLast, toSentence and toSentenceWith.
 
 # 1.54.0
 - Add `domLens` functions: 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ﻿# 1.55.0
-- Added intersperse, intersperseGrammar and toSentence.
+- Added intersperse, differentLast and toSentence.
 
 # 1.54.0
 - Add `domLens` functions: 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
-# 1.55.0
-- Added intersperseWith, intersperse, intersperseGrammar and toSentence.
+﻿# 1.55.0
+- Added intersperse, intersperseGrammar and toSentence.
 
 # 1.54.0
 - Add `domLens` functions: 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+﻿# 1.53.0
+- Added toSentenceWith and toSentence.
+
 # 1.52.0
 - Add a default export with all methods to support `import F` instead of `import * as F`
 - Also publish as `futil`!

--- a/README.md
+++ b/README.md
@@ -199,6 +199,11 @@ Haskell's [groupBy](http://zvon.org/other/haskell/Outputlist/groupBy_f.html).
 ### toggleElementBy
 `bool -> value -> list -> newList` Just like toggleElement, but takes an iteratee to determine if it should remove or add. This is useful for example in situations where you might have a checkbox that you want to represent membership of a value in a set instead of an implicit toggle. Used by includeLens.
 
+### toSentenceWith
+`(separator, lastSeparator, array) -> array`, receives two
+separators, `separator` for the initial part of the given array,
+`lastSeparator` connector `b` for the last pair of the array.
+
 ## Object
 
 ### singleObject
@@ -350,12 +355,6 @@ Maps `_.trim` through all the strings of a given object or array.
 `insertAtIndex -> (index, val, string) -> string` Insert a string at a specific index.
 
 Example: `(1, '123', 'hi') -> 'h123i'`
-
-### toSentenceWith
-`(separator, lastSeparator, join, array) -> join()`, receives two
-separators, `separator` for the initial part of the given array,
-`lastSeparator` connector `b` for the last pair of the array. The
-results get flattened and mixed with `join` function.
 
 ## toSentence
 `array => string` joins an array into a string. All the initial

--- a/README.md
+++ b/README.md
@@ -70,6 +70,15 @@ A `_.debounce` for async functions that ensure the returned promise is resolved 
 `(f1, f2, ...fn) -> f1Arg1 -> f1Arg2 -> ...f1ArgN -> fn(f2(f1))`
 Flurry is combo of flow + curry, preserving the arity of the initial function. See https://github.com/lodash/lodash/issues/3612.
 
+## Iterators
+
+### differentLast
+`(((acc, i, xs) -> a), (acc, i, xs) -> a) -> (acc, i, xs) -> a` used
+to generate an iterator that will answer with the result of the first
+given iterator for all of the properties of the iterated list except
+for the last one, which will be answered with the result of the second
+given iterator.
+
 ## Logic
 
 ### overNone
@@ -203,26 +212,21 @@ Haskell's [groupBy](http://zvon.org/other/haskell/Outputlist/groupBy_f.html).
 `(f, array) -> array` For each element of the array, it breaks the
 array in two, the first half up to the element before the current
 element and the last half containing the current element and the
-subsequent ones. This two parts are sent to the function `f`. The
-result of the function is added right before the current element of
-the iteration. Produces a new array with the changes.
+subsequent ones. The function `f` is treated as an iterator, so it
+will receive the accumulator, the current index and the full array.
+The result of the function is added right before the current element
+of the iteration. Produces a new array with the changes.
 
 If the parameter `f` is not a function, it adds the given value `x` as
 a new element between each existing element of the array. Produces a
 new array with the changes.
 
-### intersperseGrammar
-`(a, b, array) -> array`, receives two
-separators, the first one `a` will be intercalated between all but the
-last two elements of the array, then `b` for the last pair of elements.
-Produces a new array with the changes.
+**Note:** Intersperse can be used with JSX components! Specially with
+the `differentLast` iterator:
 
-**Note:** All of the intersperse functions can be used with JSX
-components!
-
-Example with words: 
+Example with words:
 ```
-> F.intersperseGrammar('or', 'or perhaps', ['first', 'second', 'third'])
+> F.intersperse(differentLast(() => 'or', () => 'or perhaps'), ['first', 'second', 'third'])
 ['first', 'or', 'second', 'or perhaps', 'third']
 ```
 
@@ -235,7 +239,7 @@ return <div>
   {
     _.flow(
       _.map(x => <b>{x}</b>),
-      F.intersperseGramar(', ', ' and ')
+      F.intersperse(F.differentLast(() => ', ', () => ' and '))
     )(results)
   }
 </div>

--- a/README.md
+++ b/README.md
@@ -199,10 +199,23 @@ Haskell's [groupBy](http://zvon.org/other/haskell/Outputlist/groupBy_f.html).
 ### toggleElementBy
 `bool -> value -> list -> newList` Just like toggleElement, but takes an iteratee to determine if it should remove or add. This is useful for example in situations where you might have a checkbox that you want to represent membership of a value in a set instead of an implicit toggle. Used by includeLens.
 
-### toSentenceWith
-`(separator, lastSeparator, array) -> array`, receives two
-separators, `separator` for the initial part of the given array,
-`lastSeparator` connector `b` for the last pair of the array.
+### intercalateWith
+`(f, array) -> array` For each element of the array, it breaks the
+array in two (the last half containing the current element), then adds
+right before the current element of the array the result of calling
+the given function `f` with both halfs of the array. Produces a new
+array with the changes.
+
+### intercalate
+`(x, array) => array` Adds the given value `x` as a new element
+between each existing element of the array. Produces a new array with
+the changes.
+
+### intercalateGrammar
+`(a, b, array) -> array`, receives two
+separators, the first one `a` will be intercalated between all but the
+last two elements of the array, then `b` for the last pair of elements.
+Produces a new array with the changes.
 
 ## Object
 

--- a/README.md
+++ b/README.md
@@ -201,10 +201,11 @@ Haskell's [groupBy](http://zvon.org/other/haskell/Outputlist/groupBy_f.html).
 
 ### intersperseWith
 `(f, array) -> array` For each element of the array, it breaks the
-array in two (the last half containing the current element), then adds
-right before the current element of the array the result of calling
-the given function `f` with both halfs of the array. Produces a new
-array with the changes.
+array in two, the first half up to the element before the current
+element and the last half containing the current element and the
+subsequent ones. This two parts are sent to the function `f`. The
+result of the function is added right before the current element of
+the iteration. Produces a new array with the changes.
 
 ### intersperse
 `(x, array) => array` Adds the given value `x` as a new element
@@ -216,6 +217,34 @@ the changes.
 separators, the first one `a` will be intercalated between all but the
 last two elements of the array, then `b` for the last pair of elements.
 Produces a new array with the changes.
+
+**Note:** All of the intersperse functions can be used with JSX
+components!
+
+Example with words: 
+```
+> F.intersperseGrammar('or', 'or perhaps', ['first', 'second', 'third'])
+['first', 'or', 'second', 'or perhaps', 'third']
+```
+
+Example with React and JSX:
+```
+let results = [1, 2, 3]
+return <div>
+  <b>Results:</b>
+  <br/>
+  {
+    _.flow(
+      _.map(x => <b>{x}</b>),
+      F.intersperseGramar(', ', ' and ')
+    )(results)
+  }
+</div>
+```
+
+Output:
+> **Results:**  
+> **1**, **2** and **3**.
 
 ## Object
 

--- a/README.md
+++ b/README.md
@@ -401,7 +401,7 @@ Maps `_.trim` through all the strings of a given object or array.
 
 Example: `(1, '123', 'hi') -> 'h123i'`
 
-## toSentence
+### toSentence
 `array => string` joins an array into a string. All the initial
 elements are joined with `, `, the last pair is joined with ` and `.
 

--- a/README.md
+++ b/README.md
@@ -199,19 +199,19 @@ Haskell's [groupBy](http://zvon.org/other/haskell/Outputlist/groupBy_f.html).
 ### toggleElementBy
 `bool -> value -> list -> newList` Just like toggleElement, but takes an iteratee to determine if it should remove or add. This is useful for example in situations where you might have a checkbox that you want to represent membership of a value in a set instead of an implicit toggle. Used by includeLens.
 
-### intercalateWith
+### intersperseWith
 `(f, array) -> array` For each element of the array, it breaks the
 array in two (the last half containing the current element), then adds
 right before the current element of the array the result of calling
 the given function `f` with both halfs of the array. Produces a new
 array with the changes.
 
-### intercalate
+### intersperse
 `(x, array) => array` Adds the given value `x` as a new element
 between each existing element of the array. Produces a new array with
 the changes.
 
-### intercalateGrammar
+### intersperseGrammar
 `(a, b, array) -> array`, receives two
 separators, the first one `a` will be intercalated between all but the
 last two elements of the array, then `b` for the last pair of elements.

--- a/README.md
+++ b/README.md
@@ -390,13 +390,13 @@ Maps `_.trim` through all the strings of a given object or array.
 
 Example: `(1, '123', 'hi') -> 'h123i'`
 
-### toSentence
-`array => string` joins an array into a string. All the initial elements are joined with `, `, the last pair is joined with ` and `.
-
 ### toSentenceWith
 `(x, array) => string` joins an array into a string. All the initial
 elements are joined with `, `, the last pair is joined with the given
 value `x`.
+
+### toSentence
+`array => string` joins an array into a string. All the initial elements are joined with `, `, the last pair is joined with ` and `.
 
 ## Regex
 

--- a/README.md
+++ b/README.md
@@ -209,19 +209,11 @@ Haskell's [groupBy](http://zvon.org/other/haskell/Outputlist/groupBy_f.html).
 `bool -> value -> list -> newList` Just like toggleElement, but takes an iteratee to determine if it should remove or add. This is useful for example in situations where you might have a checkbox that you want to represent membership of a value in a set instead of an implicit toggle. Used by includeLens.
 
 ### intersperse
-`(f, array) -> array` The function `f` is treated as an iterator, so
-it will receive the accumulator, the current index and the full array.
-The result of the function is added right before the current element
-of the iteration. Produces a new array with the changes.
+`f -> array -> [array[0], f(), array[n], ....)` Puts the result of calling `f` in between each element of the array. `f` is a standard lodash iterator taking the value, index, and list. If `f` isn't a function, it will treat `f` as the value to intersperse. See https://ramdajs.com/docs/#intersperse.
 
-If the parameter `f` is not a function, it adds the given value `x` as
-a new element between each existing element of the array. Produces a
-new array with the changes.
+**Note:** Intersperse can be used with JSX components! Specially with the `differentLast` iterator:
 
-**Note:** Intersperse can be used with JSX components! Specially with
-the `differentLast` iterator:
-
-Example with words:
+Example with words (toSentence is basically this flowed into a `_.join('')`):
 ```
 > F.intersperse(differentLast(() => 'or', () => 'or perhaps'), ['first', 'second', 'third'])
 ['first', 'or', 'second', 'or perhaps', 'third']
@@ -399,8 +391,7 @@ Maps `_.trim` through all the strings of a given object or array.
 Example: `(1, '123', 'hi') -> 'h123i'`
 
 ### toSentence
-`array => string` joins an array into a string. All the initial
-elements are joined with `, `, the last pair is joined with ` and `.
+`array => string` joins an array into a string. All the initial elements are joined with `, `, the last pair is joined with ` and `.
 
 ## Regex
 

--- a/README.md
+++ b/README.md
@@ -391,9 +391,9 @@ Maps `_.trim` through all the strings of a given object or array.
 Example: `(1, '123', 'hi') -> 'h123i'`
 
 ### toSentenceWith
-`(x, array) => string` joins an array into a string. All the initial
-elements are joined with `, `, the last pair is joined with the given
-value `x`.
+`(separator, lastSeparator, array) => string` joins an array into a string. All the initial
+elements are joined with the given `separator`, the last pair is
+joined with the given `lastSeparator`.
 
 ### toSentence
 `array => string` joins an array into a string. All the initial elements are joined with `, `, the last pair is joined with ` and `.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<a href='https://smartprocure.github.io/futil-js/'><img src='https://user-images.githubusercontent.com/8062245/28718527-796382ac-7374-11e7-98a3-9791223042a4.png' width='200' alt='futil-js'></a>
+﻿<a href='https://smartprocure.github.io/futil-js/'><img src='https://user-images.githubusercontent.com/8062245/28718527-796382ac-7374-11e7-98a3-9791223042a4.png' width='200' alt='futil-js'></a>
 
 ---
 
@@ -338,6 +338,16 @@ Maps `_.trim` through all the strings of a given object or array.
 
 ### autoLabelOptions
 `[string] -> [{value:string, label:string}]` Applies `autoLabelOption` to a collection. Useful for working with option lists like generating select tag options from an array of strings.
+
+### toSentenceWith
+`(a, b, c, d) -> c(d)`, receives two connectors, the first one `a` for
+the initial part of the list `d`, the other connector `b` for the last pair of the
+list `d`, lastly, the results get flattened and mixed with the join
+function `c`.
+
+## toSentence
+`array => string` joins an array into a string. All the initial
+elements are joined with `, `, the last pair is joined with ` and `.
 
 
 ## Regex

--- a/README.md
+++ b/README.md
@@ -340,10 +340,10 @@ Maps `_.trim` through all the strings of a given object or array.
 `[string] -> [{value:string, label:string}]` Applies `autoLabelOption` to a collection. Useful for working with option lists like generating select tag options from an array of strings.
 
 ### toSentenceWith
-`(a, b, c, d) -> c(d)`, receives two connectors, the first one `a` for
-the initial part of the list `d`, the other connector `b` for the last pair of the
-list `d`, lastly, the results get flattened and mixed with the join
-function `c`.
+`(separator, lastSeparator, join, array) -> join()`, receives two
+separators, `separator` for the initial part of the given array,
+`lastSeparator` connector `b` for the last pair of the array. The
+results get flattened and mixed with `join` function.
 
 ## toSentence
 `array => string` joins an array into a string. All the initial

--- a/README.md
+++ b/README.md
@@ -73,11 +73,8 @@ Flurry is combo of flow + curry, preserving the arity of the initial function. S
 ## Iterators
 
 ### differentLast
-`(((acc, i, xs) -> a), (acc, i, xs) -> a) -> (acc, i, xs) -> a` used
-to generate an iterator that will answer with the result of the first
-given iterator for all of the properties of the iterated list except
-for the last one, which will be answered with the result of the second
-given iterator.
+`handleItem -> handleLastItem -> iterator` Creates an iterator that handles the last item differently for use in any function that passes `(value, index, list)` (e.g. `mapIndexed`, `eachIndexed`, etc). Both the two handlers and the result are iterator functions that take `(value, index, list)`.
+
 
 ## Logic
 
@@ -390,13 +387,16 @@ Maps `_.trim` through all the strings of a given object or array.
 
 Example: `(1, '123', 'hi') -> 'h123i'`
 
-### toSentenceWith
-`(separator, lastSeparator, array) => string` joins an array into a string. All the initial
-elements are joined with the given `separator`, the last pair is
-joined with the given `lastSeparator`.
-
 ### toSentence
-`array => string` joins an array into a string. All the initial elements are joined with `, `, the last pair is joined with ` and `.
+`array => string` joins an array into a human readable string. See https://github.com/epeli/underscore.string#tosentencearray-delimiter-lastdelimiter--string
+
+Example: `['a', 'b', 'c'] -> 'a, b and c'`
+
+### toSentenceWith
+`(separator, lastSeparator, array) => string` Just like `toSentence`, but with the ability to override the `separator` and `lastSeparator`
+
+Example: `(' - ', ' or ', ['a', 'b', 'c']) -> 'a - b or c'`
+
 
 ## Regex
 

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ Haskell's [groupBy](http://zvon.org/other/haskell/Outputlist/groupBy_f.html).
 ### toggleElementBy
 `bool -> value -> list -> newList` Just like toggleElement, but takes an iteratee to determine if it should remove or add. This is useful for example in situations where you might have a checkbox that you want to represent membership of a value in a set instead of an implicit toggle. Used by includeLens.
 
-### intersperseWith
+### intersperse
 `(f, array) -> array` For each element of the array, it breaks the
 array in two, the first half up to the element before the current
 element and the last half containing the current element and the
@@ -207,10 +207,9 @@ subsequent ones. This two parts are sent to the function `f`. The
 result of the function is added right before the current element of
 the iteration. Produces a new array with the changes.
 
-### intersperse
-`(x, array) => array` Adds the given value `x` as a new element
-between each existing element of the array. Produces a new array with
-the changes.
+If the parameter `f` is not a function, it adds the given value `x` as
+a new element between each existing element of the array. Produces a
+new array with the changes.
 
 ### intersperseGrammar
 `(a, b, array) -> array`, receives two

--- a/README.md
+++ b/README.md
@@ -209,11 +209,8 @@ Haskell's [groupBy](http://zvon.org/other/haskell/Outputlist/groupBy_f.html).
 `bool -> value -> list -> newList` Just like toggleElement, but takes an iteratee to determine if it should remove or add. This is useful for example in situations where you might have a checkbox that you want to represent membership of a value in a set instead of an implicit toggle. Used by includeLens.
 
 ### intersperse
-`(f, array) -> array` For each element of the array, it breaks the
-array in two, the first half up to the element before the current
-element and the last half containing the current element and the
-subsequent ones. The function `f` is treated as an iterator, so it
-will receive the accumulator, the current index and the full array.
+`(f, array) -> array` The function `f` is treated as an iterator, so
+it will receive the accumulator, the current index and the full array.
 The result of the function is added right before the current element
 of the iteration. Produces a new array with the changes.
 

--- a/README.md
+++ b/README.md
@@ -393,6 +393,11 @@ Example: `(1, '123', 'hi') -> 'h123i'`
 ### toSentence
 `array => string` joins an array into a string. All the initial elements are joined with `, `, the last pair is joined with ` and `.
 
+### toSentenceWith
+`(x, array) => string` joins an array into a string. All the initial
+elements are joined with `, `, the last pair is joined with the given
+value `x`.
+
 ## Regex
 
 ### testRegex

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "futil-js",
-  "version": "1.52.0",
+  "version": "1.53.0",
   "description": "F(unctional) util(ities). Resistance is futile.",
   "main": "lib/futil-js.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "futil-js",
-  "version": "1.54.0",
+  "version": "1.55.0",
   "description": "F(unctional) util(ities). Resistance is futile.",
   "main": "lib/futil-js.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "futil-js",
-  "version": "1.53.0",
+  "version": "1.54.0",
   "description": "F(unctional) util(ities). Resistance is futile.",
   "main": "lib/futil-js.js",
   "scripts": {

--- a/src/array.js
+++ b/src/array.js
@@ -99,9 +99,5 @@ export let intersperse = _.curry((f, [x0, ...xs]) =>
   reduceIndexed((acc, x, i) =>
     i === xs.length
       ? [...acc, x]
-      : [...acc, callOrReturn(f, acc, xs.slice(i)), x]
+      : [...acc, callOrReturn(f, acc, i, xs), x]
   , [x0], xs))
-
-export let intersperseGrammar = _.curry((separator, lastSeparator, array) =>
-  intersperse((a, bs) => bs.length === 1 ? lastSeparator : separator, array)
-)

--- a/src/array.js
+++ b/src/array.js
@@ -96,8 +96,10 @@ export let toggleElementBy = _.curry((check, val, arr) =>
 export let toggleElement = toggleElementBy(_.includes)
 
 export let intersperse = _.curry((f, [x0, ...xs]) =>
-  reduceIndexed((acc, x, i) =>
-    i === xs.length
-      ? [...acc, x]
-      : [...acc, callOrReturn(f, acc, i, xs), x]
-  , [x0], xs))
+  reduceIndexed(
+    (acc, x, i) =>
+      i === xs.length ? [...acc, x] : [...acc, callOrReturn(f, acc, i, xs), x],
+    [x0],
+    xs
+  )
+)

--- a/src/array.js
+++ b/src/array.js
@@ -95,17 +95,17 @@ export let toggleElementBy = _.curry((check, val, arr) =>
 )
 export let toggleElement = toggleElementBy(_.includes)
 
-export let intercalateWith = _.curry((f, [x0, ...xs]) =>
+export let intersperseWith = _.curry((f, [x0, ...xs]) =>
   reduceIndexed((acc, x, i) =>
     i === xs.length
       ? [...acc, x]
       : [...acc, f(acc, xs.slice(i)), x]
   , [x0], xs))
 
-export let intercalate = _.curry((x, array) =>
-  intercalateWith(() => x, array)
+export let intersperse = _.curry((x, array) =>
+  intersperseWith(() => x, array)
 )
 
-export let intercalateGrammar = _.curry((separator, lastSeparator, array) =>
-  intercalateWith((a, bs) => bs.length === 1 ? lastSeparator : separator, array)
+export let intersperseGrammar = _.curry((separator, lastSeparator, array) =>
+  intersperseWith((a, bs) => bs.length === 1 ? lastSeparator : separator, array)
 )

--- a/src/array.js
+++ b/src/array.js
@@ -1,7 +1,7 @@
 import _ from 'lodash/fp'
 import { callOrReturn } from './function'
 import { insertAtIndex } from './collection'
-import { mapIndexed } from './conversion'
+import { reduceIndexed } from './conversion'
 
 // TODO: Move to proper files and expose
 let callUnless = check => failFn => fn => (x, y) =>
@@ -95,9 +95,17 @@ export let toggleElementBy = _.curry((check, val, arr) =>
 )
 export let toggleElement = toggleElementBy(_.includes)
 
-export let toSentenceWith = _.curry((separator, lastSeparator, array) =>
-  _.flow(
-    mapIndexed((x, i) => [x, i === array.length - 1 ? null : i === array.length - 2 ? lastSeparator : separator]),
-    _.flatten,
-    _.compact,
-  )(array))
+export let intercalateWith = _.curry((f, [x0, ...xs]) =>
+  reduceIndexed((acc, x, i) =>
+    i === xs.length
+      ? [...acc, x]
+      : [...acc, f(acc, xs.slice(i)), x]
+  , [x0], xs))
+
+export let intercalate = _.curry((x, array) =>
+  intercalateWith(() => x, array)
+)
+
+export let intercalateGrammar = _.curry((separator, lastSeparator, array) =>
+  intercalateWith((a, bs) => bs.length === 1 ? lastSeparator : separator, array)
+)

--- a/src/array.js
+++ b/src/array.js
@@ -95,17 +95,13 @@ export let toggleElementBy = _.curry((check, val, arr) =>
 )
 export let toggleElement = toggleElementBy(_.includes)
 
-export let intersperseWith = _.curry((f, [x0, ...xs]) =>
+export let intersperse = _.curry((f, [x0, ...xs]) =>
   reduceIndexed((acc, x, i) =>
     i === xs.length
       ? [...acc, x]
-      : [...acc, f(acc, xs.slice(i)), x]
+      : [...acc, callOrReturn(f, acc, xs.slice(i)), x]
   , [x0], xs))
 
-export let intersperse = _.curry((x, array) =>
-  intersperseWith(() => x, array)
-)
-
 export let intersperseGrammar = _.curry((separator, lastSeparator, array) =>
-  intersperseWith((a, bs) => bs.length === 1 ? lastSeparator : separator, array)
+  intersperse((a, bs) => bs.length === 1 ? lastSeparator : separator, array)
 )

--- a/src/array.js
+++ b/src/array.js
@@ -1,6 +1,7 @@
 import _ from 'lodash/fp'
 import { callOrReturn } from './function'
 import { insertAtIndex } from './collection'
+import { mapIndexed } from './conversion'
 
 // TODO: Move to proper files and expose
 let callUnless = check => failFn => fn => (x, y) =>
@@ -93,3 +94,10 @@ export let toggleElementBy = _.curry((check, val, arr) =>
   (callOrReturn(check, val, arr) ? _.pull : push)(val, arr)
 )
 export let toggleElement = toggleElementBy(_.includes)
+
+export let toSentenceWith = _.curry((separator, lastSeparator, array) =>
+  _.flow(
+    mapIndexed((x, i) => [x, i === array.length - 1 ? null : i === array.length - 2 ? lastSeparator : separator]),
+    _.flatten,
+    _.compact,
+  )(array))

--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,7 @@ export * from './regex'
 export * from './lang'
 export * from './lens'
 export * from './tree'
+export * from './iterators'
 
 import * as conversion from './conversion'
 import * as collection from './collection'
@@ -25,6 +26,7 @@ import * as regex from './regex'
 import * as lang from './lang'
 import * as lens from './lens'
 import * as tree from './tree'
+import * as iterators from './iterators'
 
 // Math
 // ----
@@ -48,6 +50,7 @@ export default {
   ...lang,
   ...lens,
   ...tree,
+  ...iterators,
   greaterThanOne,
   VERSION,
 }

--- a/src/iterators.js
+++ b/src/iterators.js
@@ -1,0 +1,6 @@
+import _ from 'lodash/fp'
+
+export let differentLast = (normalCase, lastCase) =>
+  (acc, i, list) => i === list.length - 1
+    ? _.iteratee(lastCase)(acc, i, list)
+    : _.iteratee(normalCase)(acc, i, list)

--- a/src/iterators.js
+++ b/src/iterators.js
@@ -1,6 +1,6 @@
 import _ from 'lodash/fp'
 
-export let differentLast = (normalCase, lastCase) =>
-  (acc, i, list) => i === list.length - 1
+export let differentLast = (normalCase, lastCase) => (acc, i, list) =>
+  i === list.length - 1
     ? _.iteratee(lastCase)(acc, i, list)
     : _.iteratee(normalCase)(acc, i, list)

--- a/src/string.js
+++ b/src/string.js
@@ -23,11 +23,11 @@ export let autoLabelOption = a => ({
 })
 export let autoLabelOptions = _.map(autoLabelOption)
 
-export let toSentenceWith = _.curry((x, array) =>
+export let toSentenceWith = _.curry((separator, lastSeparator, array) =>
   _.flow(
-    intersperse(differentLast(() => ', ', () => x)),
+    intersperse(differentLast(() => separator, () => lastSeparator)),
     _.join('')
   )(array)
 )
 
-export let toSentence = toSentenceWith(' and ')
+export let toSentence = toSentenceWith(', ', ' and ')

--- a/src/string.js
+++ b/src/string.js
@@ -1,7 +1,7 @@
 import { map } from './collection'
 import _ from 'lodash/fp'
 import { when } from './logic'
-import { intercalateGrammar } from './array'
+import { intersperseGrammar } from './array'
 
 export const wrap = (pre, post, content) =>
   (pre || '') + content + (post || pre || '')
@@ -23,6 +23,6 @@ export let autoLabelOption = a => ({
 export let autoLabelOptions = _.map(autoLabelOption)
 
 export let toSentence = _.flow(
-  intercalateGrammar(', ', ' and '),
+  intersperseGrammar(', ', ' and '),
   _.join('')
 )

--- a/src/string.js
+++ b/src/string.js
@@ -1,6 +1,7 @@
 import { map } from './collection'
 import _ from 'lodash/fp'
 import { when } from './logic'
+import { mapIndexed } from './conversion'
 
 export const wrap = (pre, post, content) =>
   (pre || '') + content + (post || pre || '')
@@ -35,3 +36,14 @@ export let autoLabelOption = a => ({
   label: a.label || autoLabel(a.value || a),
 })
 export let autoLabelOptions = _.map(autoLabelOption)
+
+
+export let toSentenceWith = _.curry((initial, last, join, array) =>
+  _.flow(
+    mapIndexed((x, i) => [x, i === array.length - 1 ? null : i === array.length - 2 ? last : initial]),
+    _.flatten,
+    _.compact,
+    join || _.identity,
+  )(array))
+
+export let toSentence = toSentenceWith(', ', ' and ', _.join(''))

--- a/src/string.js
+++ b/src/string.js
@@ -38,9 +38,9 @@ export let autoLabelOption = a => ({
 export let autoLabelOptions = _.map(autoLabelOption)
 
 
-export let toSentenceWith = _.curry((initial, last, join, array) =>
+export let toSentenceWith = _.curry((separator, lastSeparator, join, array) =>
   _.flow(
-    mapIndexed((x, i) => [x, i === array.length - 1 ? null : i === array.length - 2 ? last : initial]),
+    mapIndexed((x, i) => [x, i === array.length - 1 ? null : i === array.length - 2 ? lastSeparator : separator]),
     _.flatten,
     _.compact,
     join || _.identity,

--- a/src/string.js
+++ b/src/string.js
@@ -1,7 +1,7 @@
 import { map } from './collection'
 import _ from 'lodash/fp'
 import { when } from './logic'
-import { mapIndexed } from './conversion'
+import { toSentenceWith } from './array'
 
 export const wrap = (pre, post, content) =>
   (pre || '') + content + (post || pre || '')
@@ -22,13 +22,7 @@ export let autoLabelOption = a => ({
 })
 export let autoLabelOptions = _.map(autoLabelOption)
 
-
-export let toSentenceWith = _.curry((separator, lastSeparator, join, array) =>
-  _.flow(
-    mapIndexed((x, i) => [x, i === array.length - 1 ? null : i === array.length - 2 ? lastSeparator : separator]),
-    _.flatten,
-    _.compact,
-    join || _.identity,
-  )(array))
-
-export let toSentence = toSentenceWith(', ', ' and ', _.join(''))
+export let toSentence = _.flow(
+  toSentenceWith(', ', ' and '),
+  _.join('')
+)

--- a/src/string.js
+++ b/src/string.js
@@ -1,7 +1,8 @@
 import { map } from './collection'
 import _ from 'lodash/fp'
 import { when } from './logic'
-import { intersperseGrammar } from './array'
+import { intersperse } from './array'
+import { differentLast } from './iterators'
 
 export const wrap = (pre, post, content) =>
   (pre || '') + content + (post || pre || '')
@@ -23,6 +24,6 @@ export let autoLabelOption = a => ({
 export let autoLabelOptions = _.map(autoLabelOption)
 
 export let toSentence = _.flow(
-  intersperseGrammar(', ', ' and '),
+  intersperse(differentLast(() => ', ', () => ' and ')),
   _.join('')
 )

--- a/src/string.js
+++ b/src/string.js
@@ -27,3 +27,10 @@ export let toSentence = _.flow(
   intersperse(differentLast(() => ', ', () => ' and ')),
   _.join('')
 )
+
+export let toSentenceWith = _.curry((x, array) =>
+  _.flow(
+    intersperse(differentLast(() => ', ', () => x)),
+    _.join('')
+  )(array)
+)

--- a/src/string.js
+++ b/src/string.js
@@ -23,14 +23,11 @@ export let autoLabelOption = a => ({
 })
 export let autoLabelOptions = _.map(autoLabelOption)
 
-export let toSentence = _.flow(
-  intersperse(differentLast(() => ', ', () => ' and ')),
-  _.join('')
-)
-
 export let toSentenceWith = _.curry((x, array) =>
   _.flow(
     intersperse(differentLast(() => ', ', () => x)),
     _.join('')
   )(array)
 )
+
+export let toSentence = toSentenceWith(' and ')

--- a/src/string.js
+++ b/src/string.js
@@ -1,7 +1,7 @@
 import { map } from './collection'
 import _ from 'lodash/fp'
 import { when } from './logic'
-import { toSentenceWith } from './array'
+import { intercalateGrammar } from './array'
 
 export const wrap = (pre, post, content) =>
   (pre || '') + content + (post || pre || '')
@@ -23,6 +23,6 @@ export let autoLabelOption = a => ({
 export let autoLabelOptions = _.map(autoLabelOption)
 
 export let toSentence = _.flow(
-  toSentenceWith(', ', ' and '),
+  intercalateGrammar(', ', ' and '),
   _.join('')
 )

--- a/test/array.spec.js
+++ b/test/array.spec.js
@@ -129,9 +129,19 @@ describe('Array Functions', () => {
     expect(toggleB(true)).to.deep.equal(['a', 'b', 'c', 'b'])
     expect(toggleB(false)).to.deep.equal(['a', 'c'])
   })
-  it('toSentenceWith', () => {
+  it('intercalateWith', () => {
     expect(
-      F.toSentenceWith('or', 'or perhaps', ['first', 'second', 'third'])
+      F.intercalateWith((a, bs) => bs.length === 1 ? 'and finally' : 'and', [1, 2, 3])
+    ).to.deep.equal([ 1, 'and', 2, 'and finally', 3])
+  })
+  it('intercalate', () => {
+    expect(
+      F.intercalate('and', [1, 2, 3])
+    ).to.deep.equal([ 1, 'and', 2, 'and', 3])
+  })
+  it('intercalateGrammar', () => {
+    expect(
+      F.intercalateGrammar('or', 'or perhaps', ['first', 'second', 'third'])
     ).to.deep.equal(['first', 'or', 'second', 'or perhaps', 'third'])
   })
 })

--- a/test/array.spec.js
+++ b/test/array.spec.js
@@ -131,10 +131,17 @@ describe('Array Functions', () => {
   })
   it('intersperse', () => {
     expect(
-      F.intersperse((acc, i, xs) => i === xs.length - 1 ? 'and finally' : 'and', [1, 2, 3])
-    ).to.deep.equal([ 1, 'and', 2, 'and finally', 3])
-    expect(
-      F.intersperse('and', [1, 2, 3])
-    ).to.deep.equal([ 1, 'and', 2, 'and', 3])
+      F.intersperse(
+        (acc, i, xs) => (i === xs.length - 1 ? 'and finally' : 'and'),
+        [1, 2, 3]
+      )
+    ).to.deep.equal([1, 'and', 2, 'and finally', 3])
+    expect(F.intersperse('and', [1, 2, 3])).to.deep.equal([
+      1,
+      'and',
+      2,
+      'and',
+      3,
+    ])
   })
 })

--- a/test/array.spec.js
+++ b/test/array.spec.js
@@ -129,19 +129,19 @@ describe('Array Functions', () => {
     expect(toggleB(true)).to.deep.equal(['a', 'b', 'c', 'b'])
     expect(toggleB(false)).to.deep.equal(['a', 'c'])
   })
-  it('intercalateWith', () => {
+  it('intersperseWith', () => {
     expect(
-      F.intercalateWith((a, bs) => bs.length === 1 ? 'and finally' : 'and', [1, 2, 3])
+      F.intersperseWith((a, bs) => bs.length === 1 ? 'and finally' : 'and', [1, 2, 3])
     ).to.deep.equal([ 1, 'and', 2, 'and finally', 3])
   })
-  it('intercalate', () => {
+  it('intersperse', () => {
     expect(
-      F.intercalate('and', [1, 2, 3])
+      F.intersperse('and', [1, 2, 3])
     ).to.deep.equal([ 1, 'and', 2, 'and', 3])
   })
-  it('intercalateGrammar', () => {
+  it('intersperseGrammar', () => {
     expect(
-      F.intercalateGrammar('or', 'or perhaps', ['first', 'second', 'third'])
+      F.intersperseGrammar('or', 'or perhaps', ['first', 'second', 'third'])
     ).to.deep.equal(['first', 'or', 'second', 'or perhaps', 'third'])
   })
 })

--- a/test/array.spec.js
+++ b/test/array.spec.js
@@ -129,4 +129,9 @@ describe('Array Functions', () => {
     expect(toggleB(true)).to.deep.equal(['a', 'b', 'c', 'b'])
     expect(toggleB(false)).to.deep.equal(['a', 'c'])
   })
+  it('toSentenceWith', () => {
+    expect(
+      F.toSentenceWith('or', 'or perhaps', ['first', 'second', 'third'])
+    ).to.deep.equal(['first', 'or', 'second', 'or perhaps', 'third'])
+  })
 })

--- a/test/array.spec.js
+++ b/test/array.spec.js
@@ -131,15 +131,10 @@ describe('Array Functions', () => {
   })
   it('intersperse', () => {
     expect(
-      F.intersperse((prev, next) => next.length === 1 ? 'and finally' : 'and', [1, 2, 3])
+      F.intersperse((acc, i, xs) => i === xs.length - 1 ? 'and finally' : 'and', [1, 2, 3])
     ).to.deep.equal([ 1, 'and', 2, 'and finally', 3])
     expect(
       F.intersperse('and', [1, 2, 3])
     ).to.deep.equal([ 1, 'and', 2, 'and', 3])
-  })
-  it('intersperseGrammar', () => {
-    expect(
-      F.intersperseGrammar('or', 'or perhaps', ['first', 'second', 'third'])
-    ).to.deep.equal(['first', 'or', 'second', 'or perhaps', 'third'])
   })
 })

--- a/test/array.spec.js
+++ b/test/array.spec.js
@@ -131,7 +131,7 @@ describe('Array Functions', () => {
   })
   it('intersperseWith', () => {
     expect(
-      F.intersperseWith((a, bs) => bs.length === 1 ? 'and finally' : 'and', [1, 2, 3])
+      F.intersperseWith((prev, next) => next.length === 1 ? 'and finally' : 'and', [1, 2, 3])
     ).to.deep.equal([ 1, 'and', 2, 'and finally', 3])
   })
   it('intersperse', () => {

--- a/test/array.spec.js
+++ b/test/array.spec.js
@@ -129,12 +129,10 @@ describe('Array Functions', () => {
     expect(toggleB(true)).to.deep.equal(['a', 'b', 'c', 'b'])
     expect(toggleB(false)).to.deep.equal(['a', 'c'])
   })
-  it('intersperseWith', () => {
-    expect(
-      F.intersperseWith((prev, next) => next.length === 1 ? 'and finally' : 'and', [1, 2, 3])
-    ).to.deep.equal([ 1, 'and', 2, 'and finally', 3])
-  })
   it('intersperse', () => {
+    expect(
+      F.intersperse((prev, next) => next.length === 1 ? 'and finally' : 'and', [1, 2, 3])
+    ).to.deep.equal([ 1, 'and', 2, 'and finally', 3])
     expect(
       F.intersperse('and', [1, 2, 3])
     ).to.deep.equal([ 1, 'and', 2, 'and', 3])

--- a/test/iterators.spec.js
+++ b/test/iterators.spec.js
@@ -1,0 +1,10 @@
+import chai from 'chai'
+import F from '../src/'
+chai.expect()
+const expect = chai.expect
+
+describe('Iterator Generators', () => {
+  it('differentLast', () => {
+    expect(F.mapIndexed(F.differentLast('a', 'b'), [{a:1, b:2}, {a:1, b:2}, {a:1, b:2}])).to.eql([1, 1, 2])
+  })
+})

--- a/test/iterators.spec.js
+++ b/test/iterators.spec.js
@@ -5,6 +5,12 @@ const expect = chai.expect
 
 describe('Iterator Generators', () => {
   it('differentLast', () => {
-    expect(F.mapIndexed(F.differentLast('a', 'b'), [{a:1, b:2}, {a:1, b:2}, {a:1, b:2}])).to.eql([1, 1, 2])
+    expect(
+      F.mapIndexed(F.differentLast('a', 'b'), [
+        { a: 1, b: 2 },
+        { a: 1, b: 2 },
+        { a: 1, b: 2 },
+      ])
+    ).to.eql([1, 1, 2])
   })
 })

--- a/test/string.spec.js
+++ b/test/string.spec.js
@@ -1,3 +1,4 @@
+import _ from 'lodash/fp'
 import chai from 'chai'
 import * as f from '../src'
 chai.expect()
@@ -64,5 +65,15 @@ describe('String Functions', () => {
       { value: 'justAValue', label: 'Just A Value' },
       { value: 'bothValueAndLabel', label: 'Custom Label' },
     ])
+  })
+  it('toSentenceWith', () => {
+    expect(
+      f.toSentenceWith('or', 'or perhaps', _.join(' '), ['first', 'second', 'third'])
+    ).to.equal(`first or second or perhaps third`)
+  })
+  it('toSentence', () => {
+    expect(
+      f.toSentence(['first', 'second', 'third'])
+    ).to.equal('first, second and third')
   })
 })

--- a/test/string.spec.js
+++ b/test/string.spec.js
@@ -1,4 +1,3 @@
-import _ from 'lodash/fp'
 import chai from 'chai'
 import * as f from '../src'
 chai.expect()
@@ -65,11 +64,6 @@ describe('String Functions', () => {
       { value: 'justAValue', label: 'Just A Value' },
       { value: 'bothValueAndLabel', label: 'Custom Label' },
     ])
-  })
-  it('toSentenceWith', () => {
-    expect(
-      f.toSentenceWith('or', 'or perhaps', _.join(' '), ['first', 'second', 'third'])
-    ).to.equal(`first or second or perhaps third`)
   })
   it('toSentence', () => {
     expect(

--- a/test/string.spec.js
+++ b/test/string.spec.js
@@ -65,14 +65,14 @@ describe('String Functions', () => {
       { value: 'bothValueAndLabel', label: 'Custom Label' },
     ])
   })
-  it('toSentence', () => {
-    expect(F.toSentence(['first', 'second', 'third'])).to.equal(
-      'first, second and third'
-    )
-  })
   it('toSentenceWith', () => {
     expect(F.toSentenceWith(' or ', ['first', 'second', 'third'])).to.equal(
       'first, second or third'
+    )
+  })
+  it('toSentence', () => {
+    expect(F.toSentence(['first', 'second', 'third'])).to.equal(
+      'first, second and third'
     )
   })
 })

--- a/test/string.spec.js
+++ b/test/string.spec.js
@@ -66,9 +66,9 @@ describe('String Functions', () => {
     ])
   })
   it('toSentenceWith', () => {
-    expect(F.toSentenceWith(' or ', ['first', 'second', 'third'])).to.equal(
-      'first, second or third'
-    )
+    expect(
+      F.toSentenceWith(' - ', ' or ', ['first', 'second', 'third'])
+    ).to.equal('first - second or third')
   })
   it('toSentence', () => {
     expect(F.toSentence(['first', 'second', 'third'])).to.equal(

--- a/test/string.spec.js
+++ b/test/string.spec.js
@@ -70,4 +70,9 @@ describe('String Functions', () => {
       'first, second and third'
     )
   })
+  it('toSentenceWith', () => {
+    expect(F.toSentenceWith(' or ', ['first', 'second', 'third'])).to.equal(
+      'first, second or third'
+    )
+  })
 })

--- a/test/string.spec.js
+++ b/test/string.spec.js
@@ -66,8 +66,8 @@ describe('String Functions', () => {
     ])
   })
   it('toSentence', () => {
-    expect(
-      F.toSentence(['first', 'second', 'third'])
-    ).to.equal('first, second and third')
+    expect(F.toSentence(['first', 'second', 'third'])).to.equal(
+      'first, second and third'
+    )
   })
 })

--- a/test/string.spec.js
+++ b/test/string.spec.js
@@ -1,30 +1,30 @@
 import chai from 'chai'
-import * as f from '../src'
+import * as F from '../src'
 chai.expect()
 const expect = chai.expect
 
 describe('String Functions', () => {
   it('wrap', () => {
-    expect(f.wrap('(', ')', 'asdf')).to.equal('(asdf)')
-    expect(f.wrap(null, null, 'asdf')).to.equal('asdf')
+    expect(F.wrap('(', ')', 'asdf')).to.equal('(asdf)')
+    expect(F.wrap(null, null, 'asdf')).to.equal('asdf')
   })
   it('quote', () => {
-    expect(f.quote('asdf')).to.equal('"asdf"')
+    expect(F.quote('asdf')).to.equal('"asdf"')
   })
   it('parens', () => {
-    expect(f.parens('asdf')).to.equal('(asdf)')
+    expect(F.parens('asdf')).to.equal('(asdf)')
   })
   it('concatStrings', () => {
     expect(
-      f.concatStrings(['This ', '  is a  ', null, '', 'sentence!'])
+      F.concatStrings(['This ', '  is a  ', null, '', 'sentence!'])
     ).to.equal('This is a sentence!')
   })
   it('trimStrings', () => {
     expect(
-      f.trimStrings(['This ', '  is a  ', null, '', 'sentence!'])
+      F.trimStrings(['This ', '  is a  ', null, '', 'sentence!'])
     ).to.deep.equal(['This', 'is a', null, '', 'sentence!'])
     expect(
-      f.trimStrings({ a: 'a', b: ' b ', c: 'c ', d: ' d', e: 5 })
+      F.trimStrings({ a: 'a', b: ' b ', c: 'c ', d: ' d', e: 5 })
     ).to.deep.equal({ a: 'a', b: 'b', c: 'c', d: 'd', e: 5 })
   })
   it('autoLabel', () => {
@@ -41,20 +41,20 @@ describe('String Functions', () => {
       // Passive aggressive example of how to better auto generate PR titles from branch names...
       ['Feature/AutoLabel#126', 'Feature Auto Label 126'],
     ]
-    f.eachIndexed(
-      ([input, output]) => expect(f.autoLabel(input)).to.equal(output),
+    F.eachIndexed(
+      ([input, output]) => expect(F.autoLabel(input)).to.equal(output),
       tests
     )
   })
   it('autoLabelOption', () => {
-    expect(f.autoLabelOption('someValue')).to.deep.equal({
+    expect(F.autoLabelOption('someValue')).to.deep.equal({
       value: 'someValue',
       label: 'Some Value',
     })
   })
   it('autoLabelOptions', () => {
     expect(
-      f.autoLabelOptions([
+      F.autoLabelOptions([
         'someValue',
         { value: 'justAValue' },
         { value: 'bothValueAndLabel', label: 'Custom Label' },
@@ -67,7 +67,7 @@ describe('String Functions', () => {
   })
   it('toSentence', () => {
     expect(
-      f.toSentence(['first', 'second', 'third'])
+      F.toSentence(['first', 'second', 'third'])
     ).to.equal('first, second and third')
   })
 })


### PR DESCRIPTION
### differentLast
`(((acc, i, xs) -> a), (acc, i, xs) -> a) -> (acc, i, xs) -> a` used
to generate an iterator that will answer with the result of the first
given iterator for all of the properties of the iterated list except
for the last one, which will be answered with the result of the second
given iterator.

### intersperse
`(f, array) -> array` `(f, array) -> array` The function `f` is treated as an iterator, so
it will receive the accumulator, the current index and the full array.
The result of the function is added right before the current element
of the iteration. Produces a new array with the changes.

 **Note:** Intersperse can be used with JSX components! Specially with
the `differentLast` iterator:
 Example with words:
```
> F.intersperse(differentLast(() => 'or', () => 'or perhaps'), ['first', 'second', 'third'])
['first', 'or', 'second', 'or perhaps', 'third']
```
 Example with React and JSX:
```
let results = [1, 2, 3]
return <div>
  <b>Results:</b>
  <br/>
  {
    _.flow(
      _.map(x => <b>{x}</b>),
      F.intersperse(F.differentLast(() => ', ', () => ' and '))
    )(results)
  }
</div>
```
 Output:
> **Results:**  
> **1**, **2** and **3**.

### toSentence
`array => string` joins an array into a string. All the initial
elements are joined with `, `, the last pair is joined with ` and `.