### PR TITLE
New lens helper for React users

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
           timeout: 240
       - run:
           name: pre-danger
-          command: git config user.email "decrapifier@govspend.com" && git config user.name "Decrapifier" && git config push.default upstream && git branch -u origin/$CIRCLE_BRANCH && npm install danger
+          command: git config user.email "decrapifier@govspend.com" && git config user.name "Decrapifier" && git config push.default upstream && git branch -u origin/$CIRCLE_BRANCH
           when: always
       - run:
           name: danger

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
           timeout: 240
       - run:
           name: pre-danger
-          command: git config user.email "decrapifier@govspend.com" && git config user.name "Decrapifier" && git config push.default upstream && git branch -u origin/$CIRCLE_BRANCH
+          command: git config user.email "decrapifier@govspend.com" && git config user.name "Decrapifier" && git config push.default upstream && git branch -u origin/$CIRCLE_BRANCH && npm install danger
           when: always
       - run:
           name: danger

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-﻿# 1.55.1
+﻿# 1.55.2
+- New lens helper for React users: `stateLens`
+
+# 1.55.1
 - Fix issue with autoLabelOption not accepting correctly falsy values as valid options
 
 # 1.55.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-﻿# 1.55.2
+﻿# 1.56.0
 - New lens helper for React users: `stateLens`
 
 # 1.55.1

--- a/README.md
+++ b/README.md
@@ -560,6 +560,10 @@ To help illustrate the potential use cases of the power of lenses, these are som
 #### domLens.binding
 `(field, getValue) -> lens -> {[field], onChange}` Even more generic utility than targetBinding which uses `getEventValue` to as the function for a setsWith which is mapped to `onChange`.
 
+### Lens Utils
+
+#### stateLens
+`([value, setValue]) -> lens` Given the popularity of React, we decided to include this little helper that converts a `useState` hook call to a lens. Ex: `let lens = stateLens(useState(false))`.
 
 ## Aspect
 Aspects provide a functional oriented implementation of Aspect Oriented Programming.

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -269,14 +269,6 @@ let customLaunchers = {
     deviceName: 'iPad Pro (9.7 inch) Simulator',
     deviceOrientation: 'portrait',
   },
-  sl_android_44: {
-    base: 'SauceLabs',
-    browserName: 'android',
-    version: '4.4',
-    deviceName: 'Android Emulator',
-    deviceType: 'phone',
-    deviceOrientation: 'portrait',
-  },
   sl_android_51: {
     base: 'SauceLabs',
     browserName: 'android',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "futil-js",
-  "version": "1.55.1",
+  "version": "1.55.2",
   "description": "F(unctional) util(ities). Resistance is futile.",
   "main": "lib/futil-js.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "futil-js",
-  "version": "1.55.2",
+  "version": "1.56.0",
   "description": "F(unctional) util(ities). Resistance is futile.",
   "main": "lib/futil-js.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "license": "MIT",
   "dependencies": {
     "babel-polyfill": "^6.23.0",
+    "danger": "^8.0.0",
     "lodash": "^4.17.4"
   },
   "babel": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
   "license": "MIT",
   "dependencies": {
     "babel-polyfill": "^6.23.0",
-    "danger": "^8.0.0",
     "lodash": "^4.17.4"
   },
   "babel": {
@@ -56,6 +55,7 @@
     "chokidar-cli": "^1.2.0",
     "codacy-coverage": "^3.0.0",
     "coveralls": "^3.0.0",
+    "danger": "^6.1.13",
     "duti": "latest",
     "eslint": "4.19.1",
     "eslint-config-smartprocure": "^1.0.2",

--- a/src/lens.js
+++ b/src/lens.js
@@ -91,3 +91,5 @@ export let domLens = {
   targetBinding,
   binding,
 }
+
+export let stateLens = ([value, set]) => ({ get: () => value, set })


### PR DESCRIPTION
Given that React is so popular, export a utility function to convert a
`useState` call to a lens