### PR TITLE
Purify renameProperty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 ﻿# 1.58.1
-- Fixed issue where `renameProperty` was not a pure function.
+- Fixed issue where `renameProperty` was not a pure function. Specifically:
+ 1. The original object was mutated.
+ 2. If the original object din't have the property to be renamed the function was
+    adding the property with a value of `undefined`.
+ If code was relying in this incorrect behavior this will be a braking change.
 
-﻿# 1.58.0
+# 1.58.0
 - Add `uniqueString` and `uniqueStringWith`
 
 # 1.57.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-﻿# 1.57.0
+﻿# 1.57.1
+- Fixed issue where `renameProperty` was not a pure function.
+
+# 1.57.0
 - Added new `object` functions:
     `omitNil`
     `omitNull`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
  1. The original object was mutated.
  2. If the original object din't have the property to be renamed the function was
     adding the property with a value of `undefined`.
- If code was relying in this incorrect behavior this will be a braking change.
+ 3. If code was relying in this incorrect behavior this will be a braking change.
 
 # 1.58.0
 - Add `uniqueString` and `uniqueStringWith`

--- a/README.md
+++ b/README.md
@@ -290,10 +290,6 @@ Similar to `_.matches`, except it returns true if 1 or more object properties ma
 ### pickInto
 *TODO*
 
-### removeProperty
-`removeProperty -> targetPropertyName -> sourceObject -> sourceObject`
-Rewove a property on an object.
-
 ### renameProperty
 `sourcePropertyName -> targetPropertyName -> sourceObject -> sourceObject`
 Rename a property on an object.

--- a/README.md
+++ b/README.md
@@ -290,6 +290,9 @@ Similar to `_.matches`, except it returns true if 1 or more object properties ma
 ### pickInto
 *TODO*
 
+### removeProperty
+`removeProperty -> targetPropertyName -> sourceObject -> sourceObject`
+Rewove a property on an object.
 
 ### renameProperty
 `sourcePropertyName -> targetPropertyName -> sourceObject -> sourceObject`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "futil-js",
-  "version": "1.57.0",
+  "version": "1.57.1",
   "description": "F(unctional) util(ities). Resistance is futile.",
   "main": "lib/futil-js.js",
   "scripts": {

--- a/src/object.js
+++ b/src/object.js
@@ -44,7 +44,7 @@ export const renameProperty = _.curry((from, to, target) =>
         x => _.set(to, _.get(from, x), x),
         _.unset(from)
       )(target)
-    : _.cloneDeep(target)
+    : target
 )
 
 // { x:['a','b'], y:1 } -> [{ x:'a', y:1 }, { x:'b', y:1 }] just like mongo's `$unwind`

--- a/src/object.js
+++ b/src/object.js
@@ -41,7 +41,7 @@ export const pickInto = (map, source) => _.mapValues(pickIn(source), map)
 export const renameProperty = _.curry((from, to, target) =>
   _.has(from, target)
     ? _.flow(
-        (x) => _.set(to, _.get(from, x), x),
+        x => _.set(to, _.get(from, x), x),
         _.unset(from)
       )(target)
     : _.cloneDeep(target)

--- a/src/object.js
+++ b/src/object.js
@@ -51,17 +51,6 @@ export const renameProperty = _.curry((from, to, target) =>
     : target
 )
 
-// export const renameProperty = _.curry((from, to, target) => _.flow
-
-// {
-
-//   if (_.has(from, target)) {
-//     target = _.set(to, _.get(from, target), target)
-//     delete target[from]
-//   }
-//   return target
-// })
-
 // { x:['a','b'], y:1 } -> [{ x:'a', y:1 }, { x:'b', y:1 }] just like mongo's `$unwind`
 export const unwind = _.curry((prop, x) =>
   _.map(y => _.set(prop, y, x), _.get(prop, x))

--- a/src/object.js
+++ b/src/object.js
@@ -39,12 +39,11 @@ export const stripEmptyObjects = _.pickBy(isNotEmptyObject)
 export const pickInto = (map, source) => _.mapValues(pickIn(source), map)
 
 export const renameProperty = _.curry((from, to, target) => {
-  let o = _.cloneDeep(target)
-  if (_.has(from, o)) {
-    o[to] = o[from]
-    delete o[from]
+  if (_.has(from, target)) {
+    target = _.set(to, _.get(from, target), target)
+    delete target[from]
   }
-  return o
+  return target
 })
 
 // { x:['a','b'], y:1 } -> [{ x:'a', y:1 }, { x:'b', y:1 }] just like mongo's `$unwind`

--- a/src/object.js
+++ b/src/object.js
@@ -38,9 +38,15 @@ export const stripEmptyObjects = _.pickBy(isNotEmptyObject)
 // { a: { b: 1, c: 2 } }, [ 'b' ] -> { a: { b: 1 } }
 export const pickInto = (map, source) => _.mapValues(pickIn(source), map)
 
-export const renameProperty = _.curry((from, to, target) =>
-  _.mapKeys(_.replace(from, to), target)
-)
+export const renameProperty = _.curry((from, to, target) => {
+  let o = _.cloneDeep(target)
+  if (_.has(from, o)) {
+    let value = _.get(from, o)
+    delete o[from]
+    o[to] = value
+  }
+  return o
+})
 
 // { x:['a','b'], y:1 } -> [{ x:'a', y:1 }, { x:'b', y:1 }] just like mongo's `$unwind`
 export const unwind = _.curry((prop, x) =>

--- a/src/object.js
+++ b/src/object.js
@@ -38,13 +38,28 @@ export const stripEmptyObjects = _.pickBy(isNotEmptyObject)
 // { a: { b: 1, c: 2 } }, [ 'b' ] -> { a: { b: 1 } }
 export const pickInto = (map, source) => _.mapValues(pickIn(source), map)
 
-export const renameProperty = _.curry((from, to, target) => {
-  if (_.has(from, target)) {
-    target = _.set(to, _.get(from, target), target)
-    delete target[from]
-  }
-  return target
-})
+export const removeProperty = _.curry(
+  (prop, target) => delete target[prop] && target
+)
+export const renameProperty = _.curry((from, to, target) =>
+  _.has(from, target)
+    ? _.flow(
+        (x) => _.set(to, _.get(from, x), x),
+        removeProperty(from)
+      )(target)
+    : target
+)
+
+// export const renameProperty = _.curry((from, to, target) => _.flow
+
+// {
+
+//   if (_.has(from, target)) {
+//     target = _.set(to, _.get(from, target), target)
+//     delete target[from]
+//   }
+//   return target
+// })
 
 // { x:['a','b'], y:1 } -> [{ x:'a', y:1 }, { x:'b', y:1 }] just like mongo's `$unwind`
 export const unwind = _.curry((prop, x) =>

--- a/src/object.js
+++ b/src/object.js
@@ -38,13 +38,9 @@ export const stripEmptyObjects = _.pickBy(isNotEmptyObject)
 // { a: { b: 1, c: 2 } }, [ 'b' ] -> { a: { b: 1 } }
 export const pickInto = (map, source) => _.mapValues(pickIn(source), map)
 
-// map rename implementation (not used here yet):
-// http://jsfiddle.net/daedalus28/8uQUD/
-export const renameProperty = _.curry((from, to, target) => {
-  target[to] = target[from]
-  delete target[from]
-  return target
-})
+export const renameProperty = _.curry((from, to, target) =>
+  _.mapKeys(_.replace(from, to), target)
+)
 
 // { x:['a','b'], y:1 } -> [{ x:'a', y:1 }, { x:'b', y:1 }] just like mongo's `$unwind`
 export const unwind = _.curry((prop, x) =>

--- a/src/object.js
+++ b/src/object.js
@@ -38,17 +38,13 @@ export const stripEmptyObjects = _.pickBy(isNotEmptyObject)
 // { a: { b: 1, c: 2 } }, [ 'b' ] -> { a: { b: 1 } }
 export const pickInto = (map, source) => _.mapValues(pickIn(source), map)
 
-export const removeProperty = _.curry(
-  (prop, target) => delete target[prop] && target
-)
-
 export const renameProperty = _.curry((from, to, target) =>
   _.has(from, target)
     ? _.flow(
         (x) => _.set(to, _.get(from, x), x),
-        removeProperty(from)
+        _.unset(from)
       )(target)
-    : target
+    : _.cloneDeep(target)
 )
 
 // { x:['a','b'], y:1 } -> [{ x:'a', y:1 }, { x:'b', y:1 }] just like mongo's `$unwind`

--- a/src/object.js
+++ b/src/object.js
@@ -41,6 +41,7 @@ export const pickInto = (map, source) => _.mapValues(pickIn(source), map)
 export const removeProperty = _.curry(
   (prop, target) => delete target[prop] && target
 )
+
 export const renameProperty = _.curry((from, to, target) =>
   _.has(from, target)
     ? _.flow(

--- a/src/object.js
+++ b/src/object.js
@@ -41,9 +41,8 @@ export const pickInto = (map, source) => _.mapValues(pickIn(source), map)
 export const renameProperty = _.curry((from, to, target) => {
   let o = _.cloneDeep(target)
   if (_.has(from, o)) {
-    let value = _.get(from, o)
+    o[to] = o[from]
     delete o[from]
-    o[to] = value
   }
   return o
 })

--- a/test/objects.spec.js
+++ b/test/objects.spec.js
@@ -138,6 +138,11 @@ describe('Object Functions', () => {
       },
     })
   })
+  it('removeProperty', () => {
+    const o = { a: 1, b: 2}
+    const newO = F.removeProperty('b', o)
+    expect(newO).to.deep.equal({ a: 1 })
+  })
   it('renameProperty', () => {
     const o = { a: 1 }
     const newO = F.renameProperty('a', 'b', o)

--- a/test/objects.spec.js
+++ b/test/objects.spec.js
@@ -138,16 +138,15 @@ describe('Object Functions', () => {
       },
     })
   })
-  it('removeProperty', () => {
-    const o = { a: 1, b: 2}
-    const newO = F.removeProperty('b', o)
-    expect(newO).to.deep.equal({ a: 1 })
-  })
   it('renameProperty', () => {
     const o = { a: 1 }
     const newO = F.renameProperty('a', 'b', o)
     expect(newO).not.to.deep.equal(o)
     expect(newO).to.deep.equal({ b: 1 })
+    const new1 = F.renameProperty('c', 'b', o)
+    expect(new1).to.deep.equal(o)
+    new1.a = 2
+    expect(new1).not.to.deep.equal(o)
   })
   it('matchesSignature', () => {
     expect(F.matchesSignature([], 0)).to.equal(false)

--- a/test/objects.spec.js
+++ b/test/objects.spec.js
@@ -141,8 +141,7 @@ describe('Object Functions', () => {
   it('renameProperty', () => {
     const o = { a: 1 }
     const newO = F.renameProperty('a', 'b', o)
-    expect(o).to.deep.equal(newO)
-    expect(o).to.deep.equal({ b: 1 })
+    expect(newO).not.to.deep.equal(o)
     expect(newO).to.deep.equal({ b: 1 })
   })
   it('matchesSignature', () => {

--- a/test/objects.spec.js
+++ b/test/objects.spec.js
@@ -144,9 +144,7 @@ describe('Object Functions', () => {
     expect(newO).not.to.deep.equal(o)
     expect(newO).to.deep.equal({ b: 1 })
     const new1 = F.renameProperty('c', 'b', o)
-    expect(new1).to.deep.equal(o)
-    new1.a = 2
-    expect(new1).not.to.deep.equal(o)
+    expect(new1).to.deep.equal({ a: 1 })
   })
   it('matchesSignature', () => {
     expect(F.matchesSignature([], 0)).to.equal(false)


### PR DESCRIPTION
F.renameProperty had two issues:

1. The function was not pure meaning it had side effects.
2. The function was adding the property to be replaced to the returned object if the property did not exist.