### PR TITLE
feature/273 - export word match regex builders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-﻿# 1.58.1
+﻿# 1.59.0
+- export `anyWordToRegexp` and `wordsToRegexp`
+
+# 1.58.1
 - Fixed issue where `renameProperty` was not a pure function. Specifically:
  1. The original object was mutated.
  2. If the original object din't have the property to be renamed the function was

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "futil-js",
-  "version": "1.58.1",
+  "version": "1.59.0",
   "description": "F(unctional) util(ities). Resistance is futile.",
   "main": "lib/futil-js.js",
   "scripts": {

--- a/src/regex.js
+++ b/src/regex.js
@@ -10,12 +10,12 @@ export const makeAndTest = options =>
     testRegex
   )
 
-const anyWordToRegexp = _.flow(
+export const anyWordToRegexp = _.flow(
   _.words,
   _.join('|')
 )
 
-const wordsToRegexp = _.flow(
+export const wordsToRegexp = _.flow(
   _.words,
   _.map(x => `(?=.*${x})`),
   _.join('')


### PR DESCRIPTION
Fixes #273 

### Description
* since we want "match all words" and "match any words" functionality elsewhere and aren't always in a position to accept a match from Futil itself it's best to export these functions.
* in the current case I'll use this both in the `contexture-mongo` `filter` component and in a project that needs a contexture type that involves any-word regex matching