### PR TITLE
Update all words regex generator to match full string rather than initial empty string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-﻿# 1.59.0
+﻿# 1.59.1
+- change all words regex to report full string as match rather than empty string
+
+# 1.59.0
 - export `anyWordToRegexp` and `wordsToRegexp`
 
 # 1.58.1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "futil-js",
-  "version": "1.59.0",
+  "version": "1.59.1",
   "description": "F(unctional) util(ities). Resistance is futile.",
   "main": "lib/futil-js.js",
   "scripts": {

--- a/src/regex.js
+++ b/src/regex.js
@@ -17,7 +17,7 @@ export const anyWordToRegexp = _.flow(
 
 export const wordsToRegexp = _.flow(
   _.words,
-  _.map(x => `(?=.*${x})`),
+  _.map(x => `(?=.*${x}.*)`),
   _.join('')
 )
 

--- a/src/regex.js
+++ b/src/regex.js
@@ -18,7 +18,8 @@ export const anyWordToRegexp = _.flow(
 export const wordsToRegexp = _.flow(
   _.words,
   _.map(x => `(?=.*${x}.*)`),
-  _.join('')
+  _.join(''),
+  x => `.*${x}.*`
 )
 
 const matchWords = _.curry((buildRegex, x) => {


### PR DESCRIPTION
fixes #275 

### Description
* that extra `.*`s mean the reported match will be the full input string rather than the leading null string. the generated regexes are extensionally equivalent (e.g. they'll always give the same answer with `RegExp.test`)