### PR TITLE
Add `mergeOverAll`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-﻿# 1.59.1
+﻿# 1.60.0
+- Add `mergeOverAll`
+
+# 1.59.1
 - change all words regex to report full string as match rather than empty string
 
 # 1.59.0

--- a/README.md
+++ b/README.md
@@ -382,6 +382,9 @@ Like `_.mergeAll`, but concats arrays instead of replacing. This is basically th
 ### omitEmpty
 `_.omitBy` using `_.isEmpty` as function argument.
 
+### mergeOverAll
+`([f, g]) -> (x, y) -> {...f(x, y), ...g(x, y)}` Composition of `_.over` and `_.mergeAll`. Takes an array of functions, and returns a function that applies each one to its arguments and merges the results. Note that for functions that don't return objects, `_.merge`'s behavior is followed: for strings and arrays, the indices will be converted to keys and the result will be merged, and for all other primitives, nothing will be merged. 
+
 ## String
 
 ### parens

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "futil-js",
-  "version": "1.59.1",
+  "version": "1.60.0",
   "description": "F(unctional) util(ities). Resistance is futile.",
   "main": "lib/futil-js.js",
   "scripts": {

--- a/src/object.js
+++ b/src/object.js
@@ -185,3 +185,10 @@ export let omitNil = x => _.omitBy(_.isNil, x)
 export let omitNull = x => _.omitBy(_.isNull, x)
 export let omitBlank = x => _.omitBy(isBlank, x)
 export let omitEmpty = x => _.omitBy(_.isEmpty, x)
+
+// (f, g) -> (x, y) -> {...f(x, y), ...g(x, y)}
+export let mergeOverAll = fns =>
+  _.flow(
+    _.over(fns),
+    _.mergeAll
+  )

--- a/test/objects.spec.js
+++ b/test/objects.spec.js
@@ -588,4 +588,24 @@ describe('Object Functions', () => {
       b: 'c',
     })
   })
+  it('mergeOverAll', () => {
+    let foo = x => ({ [x]: 'foo' })
+    let bar = x => ({ bar: x, [x]: 'bar' })
+    expect(F.mergeOverAll([foo, bar])('a')).to.deep.equal({
+      a: 'bar',
+      bar: 'a',
+    })
+    expect(F.mergeOverAll([bar, foo])('a')).to.deep.equal({
+      a: 'foo',
+      bar: 'a',
+    })
+    //documenting edge case behavior
+    expect(F.mergeOverAll()()).to.deep.equal({})
+    expect(F.mergeOverAll([])()).to.deep.equal(undefined)
+    expect(F.mergeOverAll([x => x, (x, y) => y])('abc', 'de')).to.deep.equal({
+      0: 'd',
+      1: 'e',
+      2: 'c',
+    })
+  })
 })


### PR DESCRIPTION
Graduating from [contexture-react's `utils` folder](https://github.com/smartprocure/contexture-react/blob/b3c45ca05ab470be00972a2068ba93ea02dc3159/src/utils/futil.js#L17) to its own spot in the futil library 🤗