### PR TITLE
use `mergeAllArrays` in `mergeOverAll` and allow uncurried usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 1.61.1
-- Use `mergeAllArrays` in `mergeOverAll`
-- Curry `mergeOverAll`
+- Add partial currying support to `mergeOverAll`
+- Add `mergeOverAllWith` and `mergeOverAllArrays`
 
 # 1.61.0
 - Add `compactMap`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 1.61.1
 - Use `mergeAllArrays` in `mergeOverAll`
+- Curry `mergeOverAll`
 
 # 1.61.0
 - Add `compactMap`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-﻿# 1.61.0
+# 1.61.1
+- Use `mergeAllArrays` in `mergeOverAll`
+
+# 1.61.0
 - Add `compactMap`
 
 # 1.60.0

--- a/README.md
+++ b/README.md
@@ -387,9 +387,15 @@ Like `_.mergeAll`, but concats arrays instead of replacing. This is basically th
 `_.omitBy` using `_.isEmpty` as function argument.
 
 ### mergeOverAll
-`([f, g], ...args) -> {...f(...args), ...g(...args)}` Composition of `_.over` and `F.mergeAllArrays`. Takes an array of functions and an arbitrary number of arguments, calls each function with those arguments, and merges the results. Can be called with `mergeOverAll([f, g], x, y)` or `mergeOverAll([f, g])(x, y)`.
+`([f, g], ...args) -> {...f(...args), ...g(...args)}` Composition of `_.over` and `_.mergeAll`. Takes an array of functions and an arbitrary number of arguments, calls each function with those arguments, and merges the results. Can be called with `mergeOverAll([f, g], x, y)` or `mergeOverAll([f, g])(x, y)`.
 
 Note that for functions that don't return objects, `_.merge`'s behavior is followed: for strings and arrays, the indices will be converted to keys and the result will be merged, and for all other primitives, nothing will be merged. 
+
+### mergeOverAllWith
+`(customizer, [f, g], ...args) -> {...f(...args), ...g(...args)}` A customizable `mergeOverAll` that takes a function of the form `(objValue, srcValue) -> newValue` as its first argument; see [`_.mergeWith`](https://lodash.com/docs/latest#mergeWith). Both the customizer and array of functions can be partially applied.
+
+### mergeOverAllArrays
+`([f, g], ...args) -> {...f(...args), ...g(...args)}` A customized `mergeOverAll` that applies the array-merging behavior of `mergeAllArrays`.
 
 ## String
 

--- a/README.md
+++ b/README.md
@@ -387,7 +387,9 @@ Like `_.mergeAll`, but concats arrays instead of replacing. This is basically th
 `_.omitBy` using `_.isEmpty` as function argument.
 
 ### mergeOverAll
-`([f, g]) -> (x, y) -> {...f(x, y), ...g(x, y)}` Composition of `_.over` and `F.mergeAllArrays`. Takes an array of functions, and returns a function that applies each one to its arguments and merges the results. Note that for functions that don't return objects, `_.merge`'s behavior is followed: for strings and arrays, the indices will be converted to keys and the result will be merged, and for all other primitives, nothing will be merged. 
+`([f, g], ...args) -> {...f(...args), ...g(...args)}` Composition of `_.over` and `F.mergeAllArrays`. Takes an array of functions and an arbitrary number of arguments, calls each function with those arguments, and merges the results. Can be called with `mergeOverAll([f, g], x, y)` or `mergeOverAll([f, g])(x, y)`.
+
+Note that for functions that don't return objects, `_.merge`'s behavior is followed: for strings and arrays, the indices will be converted to keys and the result will be merged, and for all other primitives, nothing will be merged. 
 
 ## String
 

--- a/README.md
+++ b/README.md
@@ -387,7 +387,7 @@ Like `_.mergeAll`, but concats arrays instead of replacing. This is basically th
 `_.omitBy` using `_.isEmpty` as function argument.
 
 ### mergeOverAll
-`([f, g]) -> (x, y) -> {...f(x, y), ...g(x, y)}` Composition of `_.over` and `_.mergeAll`. Takes an array of functions, and returns a function that applies each one to its arguments and merges the results. Note that for functions that don't return objects, `_.merge`'s behavior is followed: for strings and arrays, the indices will be converted to keys and the result will be merged, and for all other primitives, nothing will be merged. 
+`([f, g]) -> (x, y) -> {...f(x, y), ...g(x, y)}` Composition of `_.over` and `F.mergeAllArrays`. Takes an array of functions, and returns a function that applies each one to its arguments and merges the results. Note that for functions that don't return objects, `_.merge`'s behavior is followed: for strings and arrays, the indices will be converted to keys and the result will be merged, and for all other primitives, nothing will be merged. 
 
 ## String
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "futil-js",
-  "version": "1.61.0",
+  "version": "1.61.1",
   "description": "F(unctional) util(ities). Resistance is futile.",
   "main": "lib/futil-js.js",
   "scripts": {

--- a/src/object.js
+++ b/src/object.js
@@ -190,5 +190,5 @@ export let omitEmpty = x => _.omitBy(_.isEmpty, x)
 export let mergeOverAll = fns =>
   _.flow(
     _.over(fns),
-    _.mergeAll
+    mergeAllArrays
   )

--- a/src/object.js
+++ b/src/object.js
@@ -187,8 +187,9 @@ export let omitBlank = x => _.omitBy(isBlank, x)
 export let omitEmpty = x => _.omitBy(_.isEmpty, x)
 
 // (f, g) -> (x, y) -> {...f(x, y), ...g(x, y)}
-export let mergeOverAll = fns =>
+export let mergeOverAll = _.curryN(2, (fns, ...x) =>
   _.flow(
     _.over(fns),
     mergeAllArrays
-  )
+  )(...x)
+)

--- a/src/object.js
+++ b/src/object.js
@@ -164,7 +164,8 @@ export let pickOn = (paths = [], obj = {}) =>
     })
   )(obj)
 
-let mergeArrays = (objValue, srcValue) => _.isArray(objValue) ? objValue.concat(srcValue) : undefined
+let mergeArrays = (objValue, srcValue) =>
+  _.isArray(objValue) ? objValue.concat(srcValue) : undefined
 
 // Straight from the lodash docs
 export let mergeAllArrays = _.mergeAllWith(mergeArrays)

--- a/src/object.js
+++ b/src/object.js
@@ -164,12 +164,10 @@ export let pickOn = (paths = [], obj = {}) =>
     })
   )(obj)
 
+let mergeArrays = (objValue, srcValue) => _.isArray(objValue) ? objValue.concat(srcValue) : undefined
+
 // Straight from the lodash docs
-export let mergeAllArrays = _.mergeAllWith((objValue, srcValue) => {
-  if (_.isArray(objValue)) {
-    return objValue.concat(srcValue)
-  }
-})
+export let mergeAllArrays = _.mergeAllWith(mergeArrays)
 // { a: [x, y, z], b: [x] } -> { x: [a, b], y: [a], z: [a] }
 export let invertByArray = _.flow(
   mapIndexed((arr, key) => zipObjectDeepWith(arr, () => [key])),
@@ -186,10 +184,21 @@ export let omitNull = x => _.omitBy(_.isNull, x)
 export let omitBlank = x => _.omitBy(isBlank, x)
 export let omitEmpty = x => _.omitBy(_.isEmpty, x)
 
-// (f, g) -> (x, y) -> {...f(x, y), ...g(x, y)}
+// ([f, g]) -> (x, y) -> {...f(x, y), ...g(x, y)}
 export let mergeOverAll = _.curryN(2, (fns, ...x) =>
   _.flow(
     _.over(fns),
-    mergeAllArrays
+    _.mergeAll
   )(...x)
 )
+
+// customizer -> ([f, g]) -> (x, y) -> {...f(x, y), ...g(x, y)}
+export let mergeOverAllWith = _.curryN(3, (customizer, fns, ...x) =>
+  _.flow(
+    _.over(fns),
+    _.mergeAllWith(customizer)
+  )(...x)
+)
+
+// ([f, g]) -> (x, y) -> {...f(x, y), ...g(x, y)}
+export let mergeOverAllArrays = mergeOverAllWith(mergeArrays)

--- a/test/objects.spec.js
+++ b/test/objects.spec.js
@@ -527,6 +527,7 @@ describe('Object Functions', () => {
       a: 3,
       b: [2, 3, 4],
     })
+    expect(F.mergeAllArrays([{a: [1], b: 5}, {a: [2]}])).to.deep.equal({a: [1, 2], b: 5})
   })
   it('invertByArray', () => {
     expect(
@@ -599,18 +600,27 @@ describe('Object Functions', () => {
       a: 'foo',
       bar: 'a',
     })
-    // should merge arrays
-    let qux = a => ({ x: a.map(x => x * x) })
-    expect(F.mergeOverAll([qux, x => ({ x })])([1, 2, 3])).to.deep.equal({ x: [1, 4, 9, 1, 2, 3] })
+    // should NOT merge arrays
+    let qux = a => ({ x: a.map(x => x + 3) })
+    expect(F.mergeOverAll([x => ({ x }), qux])([1, 2, 3])).to.deep.equal({ x: [4, 5, 6] })
     // documenting edge case behavior
     expect(F.mergeOverAll(undefined, undefined)).to.deep.equal({})
-    expect(F.mergeOverAll([])(undefined)).to.deep.equal({})
-    expect(F.mergeOverAll([])([])).to.deep.equal({})
-    expect(F.mergeOverAll(undefined, [])).to.deep.equal({})
+    expect(F.mergeOverAll(undefined)(undefined)).to.deep.equal({})
+    expect(F.mergeOverAll([])(undefined)).to.deep.equal(undefined)
     expect(F.mergeOverAll([x => x, (x, y) => y])('abc', 'de')).to.deep.equal({
       0: 'd',
       1: 'e',
       2: 'c',
     })
+  })
+  it('mergeOverAllWith', () => {
+    let reverseArrayCustomizer = (objValue, srcValue) => srcValue.length ? srcValue.reverse() : srcValue
+    let qux = a => ({ x: a.map(x => x + 3) })
+    expect(F.mergeOverAllWith(reverseArrayCustomizer, [() => ({}), qux])([1, 2, 3])).to.deep.equal({ x: [6, 5, 4] })
+  })
+  it('mergeOverAllArrays', () => {
+    // should merge arrays
+    let qux = a => ({ x: a.map(x => x + 3) })
+    expect(F.mergeOverAllArrays([x => ({ x }), qux])([1, 2, 3])).to.deep.equal({ x: [1, 2, 3, 4, 5, 6] })
   })
 })

--- a/test/objects.spec.js
+++ b/test/objects.spec.js
@@ -599,7 +599,10 @@ describe('Object Functions', () => {
       a: 'foo',
       bar: 'a',
     })
-    //documenting edge case behavior
+    // should merge arrays
+    let qux = a => ({ x: a.map(x => x * x) })
+    expect(F.mergeOverAll([qux, x => ({ x })])([1, 2, 3])).to.deep.equal({ x: [1, 4, 9, 1, 2, 3] })
+    // documenting edge case behavior
     expect(F.mergeOverAll()()).to.deep.equal({})
     expect(F.mergeOverAll([])()).to.deep.equal(undefined)
     expect(F.mergeOverAll([x => x, (x, y) => y])('abc', 'de')).to.deep.equal({

--- a/test/objects.spec.js
+++ b/test/objects.spec.js
@@ -527,7 +527,10 @@ describe('Object Functions', () => {
       a: 3,
       b: [2, 3, 4],
     })
-    expect(F.mergeAllArrays([{a: [1], b: 5}, {a: [2]}])).to.deep.equal({a: [1, 2], b: 5})
+    expect(F.mergeAllArrays([{ a: [1], b: 5 }, { a: [2] }])).to.deep.equal({
+      a: [1, 2],
+      b: 5,
+    })
   })
   it('invertByArray', () => {
     expect(
@@ -602,7 +605,9 @@ describe('Object Functions', () => {
     })
     // should NOT merge arrays
     let qux = a => ({ x: a.map(x => x + 3) })
-    expect(F.mergeOverAll([x => ({ x }), qux])([1, 2, 3])).to.deep.equal({ x: [4, 5, 6] })
+    expect(F.mergeOverAll([x => ({ x }), qux])([1, 2, 3])).to.deep.equal({
+      x: [4, 5, 6],
+    })
     // documenting edge case behavior
     expect(F.mergeOverAll(undefined, undefined)).to.deep.equal({})
     expect(F.mergeOverAll(undefined)(undefined)).to.deep.equal({})
@@ -614,13 +619,18 @@ describe('Object Functions', () => {
     })
   })
   it('mergeOverAllWith', () => {
-    let reverseArrayCustomizer = (objValue, srcValue) => srcValue.length ? srcValue.reverse() : srcValue
+    let reverseArrayCustomizer = (objValue, srcValue) =>
+      srcValue.length ? srcValue.reverse() : srcValue
     let qux = a => ({ x: a.map(x => x + 3) })
-    expect(F.mergeOverAllWith(reverseArrayCustomizer, [() => ({}), qux])([1, 2, 3])).to.deep.equal({ x: [6, 5, 4] })
+    expect(
+      F.mergeOverAllWith(reverseArrayCustomizer, [() => ({}), qux])([1, 2, 3])
+    ).to.deep.equal({ x: [6, 5, 4] })
   })
   it('mergeOverAllArrays', () => {
     // should merge arrays
     let qux = a => ({ x: a.map(x => x + 3) })
-    expect(F.mergeOverAllArrays([x => ({ x }), qux])([1, 2, 3])).to.deep.equal({ x: [1, 2, 3, 4, 5, 6] })
+    expect(F.mergeOverAllArrays([x => ({ x }), qux])([1, 2, 3])).to.deep.equal({
+      x: [1, 2, 3, 4, 5, 6],
+    })
   })
 })

--- a/test/objects.spec.js
+++ b/test/objects.spec.js
@@ -603,8 +603,10 @@ describe('Object Functions', () => {
     let qux = a => ({ x: a.map(x => x * x) })
     expect(F.mergeOverAll([qux, x => ({ x })])([1, 2, 3])).to.deep.equal({ x: [1, 4, 9, 1, 2, 3] })
     // documenting edge case behavior
-    expect(F.mergeOverAll()()).to.deep.equal({})
-    expect(F.mergeOverAll([])()).to.deep.equal(undefined)
+    expect(F.mergeOverAll(undefined, undefined)).to.deep.equal({})
+    expect(F.mergeOverAll([])(undefined)).to.deep.equal({})
+    expect(F.mergeOverAll([])([])).to.deep.equal({})
+    expect(F.mergeOverAll(undefined, [])).to.deep.equal({})
     expect(F.mergeOverAll([x => x, (x, y) => y])('abc', 'de')).to.deep.equal({
       0: 'd',
       1: 'e',


### PR DESCRIPTION
Fixes #281

The last commit adds partial autocurrying (and tests) to `mergeOverAll`, such that it supports `([f, g], ...args)` in addition to `([f, g])(...args)`. Not part of the issue, but seemed like it'd be nice to have. 🙂