### PR TITLE
Clarify `chunkBy` description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-﻿# 1.63.0
+﻿# 1.63.1
+- Clarify `chunkBy` description in README
+
+# 1.63.0
 - Add partial currying support to `mergeOverAll`
 - Add `mergeOverAllWith` and `mergeOverAllArrays`
 

--- a/README.md
+++ b/README.md
@@ -198,10 +198,9 @@ A version of `_.zipObjectDeep` that supports passing a function to determine val
 `{ encode: ['a', 'b'] -> 'a/b', decode: 'a/b' -> ['a', 'b'] }` An encoder using `/` as the separator
 
 ### chunkBy
-`((a, a) -> Boolean) -> [a] -> [[a]]` Returns an array of
-arrays, where each one of the arrays has one or more elements of the
-original array, grouped by the first function received. Similar to
-Haskell's [groupBy](http://zvon.org/other/haskell/Outputlist/groupBy_f.html).
+`(([a], a) -> Boolean) -> [a] -> [[a]]` Takes a predicate function and an array, and returns an array of arrays where each element has one or more elements of the original array. Similar to Haskell's [groupBy](http://zvon.org/other/haskell/Outputlist/groupBy_f.html).
+
+The predicate is called with two arguments: the current group, and the current element. If it returns truthy, the element is appended to the current group; otherwise, it's used as the first element in a new group.
 
 ### toggleElement
 `(any, array) -> array` Removes an element from an array if it's included in the array, or pushes it in if it doesn't. Immutable (so it's a clone of the array).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "futil-js",
-  "version": "1.63.0",
+  "version": "1.63.1",
   "description": "F(unctional) util(ities). Resistance is futile.",
   "main": "lib/futil-js.js",
   "scripts": {


### PR DESCRIPTION
This has been bothering me - the description was super vague about how the predicate should work, and it didn't help that our function signature was wrong (the first argument of the predicate should be `[a]`, not `a`). Hopefully it's much clearer now 🙂