### PR TITLE
Fix targetBinding for synthetic events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.64.1
+- Use `_.hasIn` in `targetBinding` to account for objects with `target` as an inherited property (eg, in synthetic DOM events)
+
 # 1.64.0
 - Add new native lens formats, `arrayLens` and `functionPairLens`
 - Make `domLens.value` more flexible by supporting non-native onChange events (allow `targetBinding` to fall back to the provided value if `e.target[key]` is not passed in)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "futil-js",
-  "version": "1.64.0",
+  "version": "1.64.1",
   "description": "F(unctional) util(ities). Resistance is futile.",
   "main": "lib/futil-js.js",
   "scripts": {

--- a/src/lens.js
+++ b/src/lens.js
@@ -83,7 +83,7 @@ let binding = (value, getEventValue) => (...lens) => ({
 })
 // Dom events have relevent fields on the `target` property of event objects
 let targetBinding = field =>
-  binding(field, when(_.has(`target.${field}`), _.get(`target.${field}`)))
+  binding(field, when(_.hasIn(`target.${field}`), _.get(`target.${field}`)))
 export let domLens = {
   value: targetBinding('value'),
   checkboxValues: _.flow(

--- a/test/lens.spec.js
+++ b/test/lens.spec.js
@@ -278,13 +278,20 @@ describe('Lens Functions', () => {
       expect(state.focusing).to.be.false
     })
     it('targetBinding', () => {
-      let state = {
-        flag: false,
-      }
-      let props = F.domLens.targetBinding('checked')('flag', state)
-      expect(props.checked).to.be.false
-      props.onChange({ target: { checked: true } })
-      expect(state.flag)
+      let state = { color: 'red' }
+      let props = F.domLens.targetBinding('x')('color', state)
+      expect(props.x).to.equal('red')
+      props.onChange({ target: { x: 'green' } })
+      expect(state.color).to.equal('green')
+      // should handle objects with `target` as an inherited property
+      function Event() {}
+      Event.prototype.target = {}
+      Event.prototype.target.x = 'blue'
+      props.onChange(new Event())
+      expect(state.color).to.equal('blue')
+      // should handle targetless arguments
+      props.onChange('purple')
+      expect(state.color).to.equal('purple')
     })
     it('binding', () => {
       let state = {


### PR DESCRIPTION
also more colorful tests 🎨

note: the prototype case does indeed fail when `_.has` is used in `targetBinding` instead of `_.hasIn`