### PR TITLE
Fix `invertByArray` to treat keys as literals | issue #257

### DIFF
--- a/src/object.js
+++ b/src/object.js
@@ -1,5 +1,5 @@
 import _ from 'lodash/fp'
-import { dotJoinWith, zipObjectDeepWith } from './array'
+import { dotJoinWith } from './array'
 import { overNone } from './logic'
 import { isNotNil, isBlank } from './lang'
 import {
@@ -171,7 +171,10 @@ let mergeArrays = (objValue, srcValue) =>
 export let mergeAllArrays = _.mergeAllWith(mergeArrays)
 // { a: [x, y, z], b: [x] } -> { x: [a, b], y: [a], z: [a] }
 export let invertByArray = _.flow(
-  mapIndexed((arr, key) => zipObjectDeepWith(arr, () => [key])),
+  mapIndexed((arr, key) =>
+    _.zipObject(arr, arr.map(() => [key]))
+  ),
+
   mergeAllArrays
 )
 

--- a/src/object.js
+++ b/src/object.js
@@ -170,7 +170,7 @@ let mergeArrays = (objValue, srcValue) =>
 // Straight from the lodash docs
 export let mergeAllArrays = _.mergeAllWith(mergeArrays)
 // { a: [x, y, z], b: [x] } -> { x: [a, b], y: [a], z: [a] }
-export let invertByArray = _.flow(
+export const invertByArray = _.flow(
   mapIndexed((arr, key) =>
     _.zipObject(arr, arr.map(() => [key]))
   ),

--- a/test/objects.spec.js
+++ b/test/objects.spec.js
@@ -536,13 +536,15 @@ describe('Object Functions', () => {
   it('invertByArray', () => {
     expect(
       F.invertByArray({
-        a: ['x', 'y', 'z'],
-        b: ['x'],
+        a: ['v.w', 'x', '.y', 'z'],
+        b: ['v[w]', 'x'],
       })
     ).to.deep.equal({
+      'v.w': ['a'],
       x: ['a', 'b'],
-      y: ['a'],
+      '.y': ['a'],
       z: ['a'],
+      'v[w]': ['b'],
     })
   })
   it('stampKey', () => {


### PR DESCRIPTION
If I understand the intended usage correctly, this should fix #257. At any rate, the original tests pass with the change.

It seems that any path-like key is affected and it's not limited to keys with a leading `.`.