### PR TITLE
Use onMouseEnter/Leave in domLens.hover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.64.4
+- Change `domLens.hover` to use `onMouseEnter`/`onMouseLeave` instead of `onMouseOver`/`onMouseOut`
+
 # 1.64.3
 - Fix typo in README
 

--- a/README.md
+++ b/README.md
@@ -612,7 +612,7 @@ let Component = () => {
 `(value, lens) -> {checked, onChange}` Creates an includeLens and maps view to checked and set to `onChange` (set with `e.target.checked` or `e` if that path isn't present)
 
 #### domLens.hover
-`lens -> { onMouseOver, onMouseOut }` Takes a lens and returns on onMouseOver which calls `on` on the lens and onMouseOut which calls `off`. Models a mapping of "hovering" to a boolean.
+`lens -> { onMouseEnter, onMouseLeave }` Takes a lens and returns on onMouseEnter which calls `on` on the lens and onMouseLeave which calls `off`. Models a mapping of "hovering" to a boolean.
 
 #### domLens.focus
 `lens -> { onFocus, onBlur }` Takes a lens and returns on onFocus which calls `on` on the lens and onBlur which calls `off`. Models a mapping of "focusing" to a boolean.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "futil-js",
-  "version": "1.64.3",
+  "version": "1.64.4",
   "description": "F(unctional) util(ities). Resistance is futile.",
   "main": "lib/futil-js.js",
   "scripts": {

--- a/runkit.example.js
+++ b/runkit.example.js
@@ -5,5 +5,8 @@ var cities = ['London', 'Boston', 'Lisbon']
 F.dotJoinWith(c => c.startsWith('L'))(cities)
 // "London.Lisbon"
 
-F.arrayToObject(c => c.toLowerCase(), c => c.toUpperCase())(cities)
+F.arrayToObject(
+  c => c.toLowerCase(),
+  c => c.toUpperCase()
+)(cities)
 // {boston: "BOSTON", lisbon: "LISBON", london: "LONDON"}

--- a/src/array.js
+++ b/src/array.js
@@ -31,10 +31,7 @@ export let pushOn = _.curry((arr, val) => {
 })
 
 export let moveIndex = (from, to, arr) =>
-  _.flow(
-    _.pullAt(from),
-    insertAtIndex(to, arr[from])
-  )(arr)
+  _.flow(_.pullAt(from), insertAtIndex(to, arr[from]))(arr)
 
 let overlaps = (x, y) => y[0] > x[1]
 let mergeRange = (x, y) => [[x[0], _.max(x.concat(y))]]
@@ -56,10 +53,7 @@ export let mergeRanges = _.flow(
 export let cycle = _.curry((a, n) => a[(a.indexOf(n) + 1) % a.length])
 
 export let arrayToObject = _.curry((k, v, a) =>
-  _.flow(
-    _.keyBy(k),
-    _.mapValues(v)
-  )(a)
+  _.flow(_.keyBy(k), _.mapValues(v))(a)
 )
 
 // zipObject that supports functions instead of objects

--- a/src/collection.js
+++ b/src/collection.js
@@ -30,8 +30,5 @@ export let insertAtIndex = _.curry((index, val, collection) =>
 )
 
 export let compactMap = _.curry((fn, collection) =>
-  _.flow(
-    _.map(fn),
-    _.compact
-  )(collection)
+  _.flow(_.map(fn), _.compact)(collection)
 )

--- a/src/conversion.js
+++ b/src/conversion.js
@@ -27,17 +27,21 @@ export const updateOn = mutable.update
 // Uncaps
 // ------
 // Un-prefixed Deprecated
-export const reduce = aspects.deprecate('reduce', '1.28.0', 'reduceIndexed')(
-  noCap.reduce
-)
+export const reduce = aspects.deprecate(
+  'reduce',
+  '1.28.0',
+  'reduceIndexed'
+)(noCap.reduce)
 export const mapValues = aspects.deprecate(
   'mapValues',
   '1.28.0',
   'mapValuesIndexed'
 )(noCap.mapValues)
-export const each = aspects.deprecate('each', '1.28.0', 'eachIndexed')(
-  noCap.each
-)
+export const each = aspects.deprecate(
+  'each',
+  '1.28.0',
+  'eachIndexed'
+)(noCap.each)
 
 export const mapIndexed = noCap.map
 export const findIndexed = noCap.find

--- a/src/lens.js
+++ b/src/lens.js
@@ -86,10 +86,7 @@ let targetBinding = field =>
   binding(field, when(_.hasIn(`target.${field}`), _.get(`target.${field}`)))
 export let domLens = {
   value: targetBinding('value'),
-  checkboxValues: _.flow(
-    includeLens,
-    targetBinding('checked')
-  ),
+  checkboxValues: _.flow(includeLens, targetBinding('checked')),
   hover: (...lens) => ({
     onMouseEnter: on(...lens),
     onMouseLeave: off(...lens),

--- a/src/lens.js
+++ b/src/lens.js
@@ -91,8 +91,8 @@ export let domLens = {
     targetBinding('checked')
   ),
   hover: (...lens) => ({
-    onMouseOver: on(...lens),
-    onMouseOut: off(...lens),
+    onMouseEnter: on(...lens),
+    onMouseLeave: off(...lens),
   }),
   focus: (...lens) => ({
     onFocus: on(...lens),

--- a/src/logic.js
+++ b/src/logic.js
@@ -3,10 +3,7 @@ import { callOrReturn } from './function'
 import { exists } from './lang'
 
 // ([f, g]) -> !f(x) && !g(x)
-export const overNone = _.flow(
-  _.overSome,
-  _.negate
-)
+export const overNone = _.flow(_.overSome, _.negate)
 
 let boolIteratee = x => (_.isBoolean(x) ? () => x : _.iteratee(x))
 // Port from Ramda

--- a/src/object.js
+++ b/src/object.js
@@ -40,10 +40,7 @@ export const pickInto = (map, source) => _.mapValues(pickIn(source), map)
 
 export const renameProperty = _.curry((from, to, target) =>
   _.has(from, target)
-    ? _.flow(
-        x => _.set(to, _.get(from, x), x),
-        _.unset(from)
-      )(target)
+    ? _.flow(x => _.set(to, _.get(from, x), x), _.unset(from))(target)
     : target
 )
 
@@ -79,11 +76,7 @@ export const matchesSignature = _.curry(
 )
 
 // `_.matches` that returns true if one or more of the conditions match instead of all
-export const matchesSome = _.flow(
-  chunkObject,
-  _.map(_.matches),
-  _.overSome
-)
+export const matchesSome = _.flow(chunkObject, _.map(_.matches), _.overSome)
 
 // Checks if a property deep in a given item equals to a given value
 export const compareDeep = _.curry(
@@ -91,9 +84,11 @@ export const compareDeep = _.curry(
 )
 
 //Depreacted in favor of _.update version from lodash
-export const mapProp = aspects.deprecate('mapProp', '1.46.0', '_.update')(
-  noCap.update
-)
+export const mapProp = aspects.deprecate(
+  'mapProp',
+  '1.46.0',
+  '_.update'
+)(noCap.update)
 
 // `_.get` that returns the target object if lookup fails
 export let getOrReturn = _.curry((prop, x) => _.getOr(x, prop, x))
@@ -135,10 +130,7 @@ export let simpleDiff = (original, deltas) => {
     _.omitBy(x => x.from === x.to)
   )(deltas)
 }
-export let simpleDiffArray = _.flow(
-  simpleDiff,
-  unkeyBy('field')
-)
+export let simpleDiffArray = _.flow(simpleDiff, unkeyBy('field'))
 
 export let diff = (original, deltas) => {
   let o = flattenObject(original)
@@ -148,10 +140,7 @@ export let diff = (original, deltas) => {
     _.omitBy(x => x.from === x.to)
   )(_.merge(o, d))
 }
-export let diffArray = _.flow(
-  diff,
-  unkeyBy('field')
-)
+export let diffArray = _.flow(diff, unkeyBy('field'))
 
 // A `_.pick` that mutates the object
 export let pickOn = (paths = [], obj = {}) =>
@@ -187,18 +176,12 @@ export let omitEmpty = x => _.omitBy(_.isEmpty, x)
 
 // ([f, g]) -> (x, y) -> {...f(x, y), ...g(x, y)}
 export let mergeOverAll = _.curryN(2, (fns, ...x) =>
-  _.flow(
-    _.over(fns),
-    _.mergeAll
-  )(...x)
+  _.flow(_.over(fns), _.mergeAll)(...x)
 )
 
 // customizer -> ([f, g]) -> (x, y) -> {...f(x, y), ...g(x, y)}
 export let mergeOverAllWith = _.curryN(3, (customizer, fns, ...x) =>
-  _.flow(
-    _.over(fns),
-    _.mergeAllWith(customizer)
-  )(...x)
+  _.flow(_.over(fns), _.mergeAllWith(customizer))(...x)
 )
 
 // ([f, g]) -> (x, y) -> {...f(x, y), ...g(x, y)}

--- a/src/regex.js
+++ b/src/regex.js
@@ -4,16 +4,9 @@ import { insertAtIndex } from './collection'
 
 export const testRegex = _.curry((regex, str) => new RegExp(regex).test(str))
 export const makeRegex = options => text => RegExp(text, options)
-export const makeAndTest = options =>
-  _.flow(
-    makeRegex(options),
-    testRegex
-  )
+export const makeAndTest = options => _.flow(makeRegex(options), testRegex)
 
-export const anyWordToRegexp = _.flow(
-  _.words,
-  _.join('|')
-)
+export const anyWordToRegexp = _.flow(_.words, _.join('|'))
 
 export const wordsToRegexp = _.flow(
   _.words,

--- a/src/string.js
+++ b/src/string.js
@@ -8,11 +8,7 @@ export const wrap = (pre, post, content) =>
   (pre || '') + content + (post || pre || '')
 export const quote = _.partial(wrap, ['"', '"'])
 export const parens = _.partial(wrap, ['(', ')'])
-export const concatStrings = _.flow(
-  _.compact,
-  _.map(_.trim),
-  _.join(' ')
-)
+export const concatStrings = _.flow(_.compact, _.map(_.trim), _.join(' '))
 export const trimStrings = map(when(_.isString, _.trim))
 
 // _.startCase does the trick, deprecate it!
@@ -25,7 +21,12 @@ export let autoLabelOptions = _.map(autoLabelOption)
 
 export let toSentenceWith = _.curry((separator, lastSeparator, array) =>
   _.flow(
-    intersperse(differentLast(() => separator, () => lastSeparator)),
+    intersperse(
+      differentLast(
+        () => separator,
+        () => lastSeparator
+      )
+    ),
     _.join('')
   )(array)
 )

--- a/src/tree.js
+++ b/src/tree.js
@@ -38,10 +38,7 @@ export let treeToArrayBy = (next = traverse) =>
 export let treeToArray = (next = traverse) => treeToArrayBy(next)(x => x)
 
 export let leaves = (next = traverse) =>
-  _.flow(
-    treeToArray(next),
-    _.reject(next)
-  )
+  _.flow(treeToArray(next), _.reject(next))
 
 export let treeLookup = (next = traverse, buildIteratee = _.identity) =>
   _.curry((path, tree) =>
@@ -73,13 +70,7 @@ export let treeValues = (x, i, xs) => [x, ...xs]
 export let treePath = (build = treeKeys, encoder = dotEncoder) => (...args) =>
   (encoder.encode || encoder)(build(...args).reverse())
 export let propTreePath = prop =>
-  treePath(
-    _.flow(
-      treeValues,
-      _.map(prop)
-    ),
-    slashEncoder
-  )
+  treePath(_.flow(treeValues, _.map(prop)), slashEncoder)
 
 export let flattenTree = (next = traverse) => (buildPath = treePath()) =>
   reduceTree(next)(

--- a/test/array.spec.js
+++ b/test/array.spec.js
@@ -19,11 +19,21 @@ describe('Array Functions', () => {
     expect(F.repeated(['a', 'b', 'b'])).to.eql(['b'])
   })
   it('mergeRanges', () => {
-    expect(F.mergeRanges([[0, 2], [1, 4]])).to.deep.equal([[0, 4]])
+    expect(
+      F.mergeRanges([
+        [0, 2],
+        [1, 4],
+      ])
+    ).to.deep.equal([[0, 4]])
     expect(F.mergeRanges([null, [1, 4]])).to.deep.equal([[1, 4]])
-    expect(F.mergeRanges([[0, 1], [1, 4], [2, 4], [3, 5]])).to.deep.equal([
-      [0, 5],
-    ])
+    expect(
+      F.mergeRanges([
+        [0, 1],
+        [1, 4],
+        [2, 4],
+        [3, 5],
+      ])
+    ).to.deep.equal([[0, 5]])
   })
   it('cycle', () => {
     let cycle = F.cycle([1, 2, 3])
@@ -41,7 +51,11 @@ describe('Array Functions', () => {
   })
   it('arrayToObject', () => {
     expect(
-      F.arrayToObject(x => `key${x}`, x => `val${x}`, ['a', 'b', 'c'])
+      F.arrayToObject(
+        x => `key${x}`,
+        x => `val${x}`,
+        ['a', 'b', 'c']
+      )
     ).to.deep.equal({ keya: 'vala', keyb: 'valb', keyc: 'valc' })
   })
   it('pushIn', () => {

--- a/test/collections.spec.js
+++ b/test/collections.spec.js
@@ -7,13 +7,12 @@ const expect = chai.expect
 
 describe('Collections Functions', () => {
   it('flowMap', () => {
-    expect(F.flowMap(n => n + n, n => n * n)([0, 1, 2, 3, 4])).to.eql([
-      0,
-      4,
-      16,
-      36,
-      64,
-    ])
+    expect(
+      F.flowMap(
+        n => n + n,
+        n => n * n
+      )([0, 1, 2, 3, 4])
+    ).to.eql([0, 4, 16, 36, 64])
     expect(
       F.flowMap(
         s => s.toUpperCase(),

--- a/test/lens.spec.js
+++ b/test/lens.spec.js
@@ -262,9 +262,9 @@ describe('Lens Functions', () => {
         hovering: false,
       }
       let props = F.domLens.hover('hovering', state)
-      props.onMouseOver()
+      props.onMouseEnter()
       expect(state.hovering).to.be.true
-      props.onMouseOut()
+      props.onMouseLeave()
       expect(state.hovering).to.be.false
     })
     it('focus', () => {

--- a/test/logic.spec.js
+++ b/test/logic.spec.js
@@ -7,13 +7,21 @@ const expect = chai.expect
 describe('Logic Functions', () => {
   describe('ifElse', () => {
     it('should handle functions', () => {
-      let clamp5 = f.ifElse(x => x > 5, () => 5, x => x)
+      let clamp5 = f.ifElse(
+        x => x > 5,
+        () => 5,
+        x => x
+      )
       expect(clamp5(3)).to.equal(3)
       expect(clamp5(5)).to.equal(5)
       expect(clamp5(13)).to.equal(5)
     })
     it('should handle passing boolean conditions', () => {
-      let fn = f.ifElse(true, x => `success ${x}`, x => `fail ${x}`)
+      let fn = f.ifElse(
+        true,
+        x => `success ${x}`,
+        x => `fail ${x}`
+      )
       expect(fn(1)).to.equal('success 1')
     })
     it('should handle fancy shorthand', () => {
@@ -23,18 +31,29 @@ describe('Logic Functions', () => {
     })
     it('should be fully curried', () => {
       expect(
-        f.ifElse(x => x % 2, x => `${x} is odd!`, x => `${x} is even!`, 6)
+        f.ifElse(
+          x => x % 2,
+          x => `${x} is odd!`,
+          x => `${x} is even!`,
+          6
+        )
       ).to.equal('6 is even!')
     })
   })
   it('when', () => {
-    let clamp5 = f.when(x => x > 5, () => 5)
+    let clamp5 = f.when(
+      x => x > 5,
+      () => 5
+    )
     expect(clamp5(3)).to.equal(3)
     expect(clamp5(5)).to.equal(5)
     expect(clamp5(13)).to.equal(5)
   })
   it('unless', () => {
-    let clamp5 = f.unless(x => x < 5, () => 5)
+    let clamp5 = f.unless(
+      x => x < 5,
+      () => 5
+    )
     expect(clamp5(3)).to.equal(3)
     expect(clamp5(5)).to.equal(5)
     expect(clamp5(13)).to.equal(5)

--- a/test/regex.spec.js
+++ b/test/regex.spec.js
@@ -57,11 +57,24 @@ describe('Regexp Functions', () => {
 describe('Posting Highlight Functions', () => {
   it('should get postings', () => {
     var result = f.postings(RegExp('p', 'gi'), 'pretty please')
-    expect(result).to.deep.equal([[0, 1], [7, 8]])
+    expect(result).to.deep.equal([
+      [0, 1],
+      [7, 8],
+    ])
   })
   it('should get postings by word', () => {
     var result = f.postingsForWords('pret pr t ', 'pretty prease')
-    expect(result).to.deep.equal([[[0, 4]], [[0, 2], [7, 9]], [[3, 4], [4, 5]]])
+    expect(result).to.deep.equal([
+      [[0, 4]],
+      [
+        [0, 2],
+        [7, 9],
+      ],
+      [
+        [3, 4],
+        [4, 5],
+      ],
+    ])
   })
   var start = '<span class="highlight">'
   var end = '</span>'
@@ -80,7 +93,15 @@ describe('Posting Highlight Functions', () => {
     let expected =
       '<span class="highlight">p</span>retty <span class="highlight">p</span>lease'
     expect(
-      f.highlightFromPostings(start, end, [[7, 8], [0, 1]], input)
+      f.highlightFromPostings(
+        start,
+        end,
+        [
+          [7, 8],
+          [0, 1],
+        ],
+        input
+      )
     ).to.equal(expected)
   })
   it('should high level highlight', () => {

--- a/test/string.spec.js
+++ b/test/string.spec.js
@@ -81,13 +81,12 @@ describe('String Functions', () => {
   it('uniqueString', () => {
     let dedupe = F.uniqueString([])
     expect(dedupe.cache).to.deep.equal({})
-    expect(_.map(dedupe, _.times(() => 'foo', 5))).to.deep.equal([
-      'foo',
-      'foo1',
-      'foo2',
-      'foo3',
-      'foo4',
-    ])
+    expect(
+      _.map(
+        dedupe,
+        _.times(() => 'foo', 5)
+      )
+    ).to.deep.equal(['foo', 'foo1', 'foo2', 'foo3', 'foo4'])
     expect(dedupe.cache).to.deep.equal({
       foo: 5,
       foo1: 1,

--- a/test/tree.spec.js
+++ b/test/tree.spec.js
@@ -179,7 +179,10 @@ describe('Tree Functions', () => {
         },
       ],
     }
-    let tree = F.tree(x => x.items, a => ({ a }))
+    let tree = F.tree(
+      x => x.items,
+      a => ({ a })
+    )
     expect(tree.lookup(['2', '4'], x)).to.deep.equal(x.items[0].items[1])
   })
   it('transform', () => {
@@ -378,10 +381,7 @@ describe('Tree Functions', () => {
       },
     }
     let Tree = F.tree(x => x.properties)
-    let result = _.flow(
-      Tree.flatten(),
-      _.omitBy(Tree.traverse)
-    )({ properties })
+    let result = _.flow(Tree.flatten(), _.omitBy(Tree.traverse))({ properties })
     expect(result).to.deep.equal({
       Field1: {
         type: 'text',


### PR DESCRIPTION
`onMouseEnter`/`onMouseLeave` are more consistent with the notion of "hovering" state on a DOM element, since they don't bubble the cursor events to children. With `onMouseOver`/`onMouseOut`, hovering over a child of the element can interfere with the event, which is probably not the behavior we want for `domLens.hover`.

https://javascript.info/mousemove-mouseover-mouseout-mouseenter-mouseleave#mouseout-when-leaving-for-a-child