### PR TITLE
Highlight stuff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.64.5
+- Add support for regular expression arguments to `highlight`
+- Clarify `highlight` description in README
+
 # 1.64.4
 - Change `domLens.hover` to use `onMouseEnter`/`onMouseLeave` instead of `onMouseOver`/`onMouseOut`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 1.64.5
 - Add support for regular expression arguments to `highlight`
 - Clarify `highlight` description in README
+- Add description for `postingsForWords` to README
 
 # 1.64.4
 - Change `domLens.hover` to use `onMouseEnter`/`onMouseLeave` instead of `onMouseOver`/`onMouseOut`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 1.64.5
+# 1.65.0
 - Add support for regular expression arguments to `highlight`
 - Clarify `highlight` description in README
 - Add description for `postingsForWords` to README

--- a/README.md
+++ b/README.md
@@ -487,6 +487,18 @@ uniqueStringWith(_.identity, dedupe.cache)('foo')  //-> 'foo4'
 ### postings
 `regex -> string -> [[number, number]]` Returns an array of postings (position ranges) for a regex and string to test, e.g. `F.postings(/a/g, 'vuhfaof') -> [[4, 5]]`
 
+### postingsForWords
+`words -> string -> [[[number, number]]]` Takes a string of words and a string to test, and returns an array of arrays of postings for each word.
+
+Example:
+```js
+F.postingsForWords('she lls', 'she sells sea shells')
+// [
+//   [[0, 3], [14, 17]]
+//   [[6, 9], [17, 20]]
+// ]
+```
+
 ### highlight
 `start -> end -> pattern -> input -> highlightedInput` Wraps the matches for `pattern` found in `input` with the strings `start` and `end`. The `pattern` argument can either be a string of words to match, or a regular expression.
 

--- a/README.md
+++ b/README.md
@@ -488,9 +488,14 @@ uniqueStringWith(_.identity, dedupe.cache)('foo')  //-> 'foo4'
 `regex -> string -> [[number, number]]` Returns an array of postings (position ranges) for a regex and string to test, e.g. `F.postings(/a/g, 'vuhfaof') -> [[4, 5]]`
 
 ### highlight
-`start -> end -> regex -> input -> highlightedInput` Wraps the matches for `regex` found in `input` with the strings `start` and `end`.
+`start -> end -> pattern -> input -> highlightedInput` Wraps the matches for `pattern` found in `input` with the strings `start` and `end`. The `pattern` argument can either be a string of words to match, or a regular expression.
 
-Example: `('<b>', '</b>', /h/, 'hi') -> '<b>h</b>i'`
+Example: 
+```js
+let braceHighlight = F.highlight('{', '}')
+braceHighlight('l o', 'hello world') //-> "he{llo} w{o}r{l}d"
+braceHighlight(/l+\w/, 'hello world') //-> "he{llo} wor{ld}"
+```
 
 ### allMatches
 `regex -> string -> [{text: string, start: number, end: number}]` Returns an array of matches with start/end data, e.g. `F.allMatches(/a/g, 'vuhfaof') -> [ { text: 'a', start: 4, end: 5 } ]`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "futil-js",
-  "version": "1.64.4",
+  "version": "1.65.0",
   "description": "F(unctional) util(ities). Resistance is futile.",
   "main": "lib/futil-js.js",
   "scripts": {

--- a/src/regex.js
+++ b/src/regex.js
@@ -77,7 +77,9 @@ export const highlight = _.curry((start, end, pattern, input) =>
   highlightFromPostings(
     start,
     end,
-    _.flatten(postingsForWords(pattern, input)),
+    _.isRegExp(pattern)
+      ? postings(pattern, input)
+      : _.flatten(postingsForWords(pattern, input)),
     input
   )
 )

--- a/test/regex.spec.js
+++ b/test/regex.spec.js
@@ -111,4 +111,11 @@ describe('Posting Highlight Functions', () => {
       '<span class="highlight">pr</span>etty <span class="highlight">pl</span>ease'
     expect(f.highlight(start, end, pattern, input)).to.deep.equal(expected)
   })
+  it('should highlight from regexp', () => {
+    let input = 'pretty please nope'
+    let pattern = /\bp\w/g
+    let expected =
+      '<span class="highlight">pr</span>etty <span class="highlight">pl</span>ease nope'
+    expect(f.highlight(start, end, pattern, input)).to.deep.equal(expected)
+  })
 })


### PR DESCRIPTION
- Add support for regular expression arguments to `highlight`
- Force global and case-insensitive matches on `postings` (for parity with `postingsForWords`)
- Clarify `highlight` description in README
- Add description for `postingsForWords` to README