### PR TITLE
Move babel-polyfill to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
   },
   "license": "MIT",
   "dependencies": {
-    "babel-polyfill": "^6.23.0",
     "lodash": "^4.17.4"
   },
   "babel": {
@@ -47,6 +46,7 @@
     "babel-eslint": "^8.0.0",
     "babel-loader": "^7.0.0",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
+    "babel-polyfill": "^6.23.0",
     "babel-preset-env": "^1.6.1",
     "bluebird": "^3.5.0",
     "chai": "^4.1.0",


### PR DESCRIPTION
This PR's intention is to implement the change described in #260 moving `babel-polyfill` to `devDependencies` instead of `dependencies`, to allow for people to choose as it was noted that [`babel-polyfill` doesn't work well with some user's environments](https://github.com/smartprocure/futil-js/issues/260#issuecomment-499156892).