### PR TITLE
kill promises in findIndexedAsync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.66.1
+- Kill promises in `findIndexedAsync` to fix regeneratorRuntime shenanigans
+
 # 1.66.0
 - Add `walkAsync`
 - Add `findIndexedAsync` (used internally and not documented, but exported for testing)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "futil-js",
-  "version": "1.66.0",
+  "version": "1.66.1",
   "description": "F(unctional) util(ities). Resistance is futile.",
   "main": "lib/futil-js.js",
   "scripts": {

--- a/src/tree.js
+++ b/src/tree.js
@@ -1,5 +1,5 @@
 import _ from 'lodash/fp'
-import { findIndexed } from './conversion'
+import { findIndexed, reduceIndexed } from './conversion'
 import { push, dotEncoder, slashEncoder } from './array'
 
 export let isTraversable = x => _.isArray(x) || _.isPlainObject(x)
@@ -18,10 +18,20 @@ export let walk = (next = traverse) => (
   ) ||
   post(tree, index, parents, parentIndexes)
 
-export let findIndexedAsync = async (f, data) => {
-  for (let key in data) {
-    if (await f(data[key], key, data)) return data[key]
-  }
+
+// async/await is so much cleaner but causes regeneratorRuntime shenanigans
+// export let findIndexedAsync = async (f, data) => {
+//   for (let key in data) {
+//     if (await f(data[key], key, data)) return data[key]
+//   }
+// }
+// The general idea here is to keep popping off key/value pairs until we hit something that matches
+export let findIndexedAsync = (f, data, remaining = _.toPairs(data)) => {
+  if (!remaining.length) return
+  let [[key, val], ...rest] = remaining
+  return Promise.resolve(f(val, key, data)).then(
+    result => result ? val : rest.length ? findIndexedAsync(f, data, rest) : undefined
+  )
 }
 
 export let walkAsync = (next = traverse) => (
@@ -29,7 +39,7 @@ export let walkAsync = (next = traverse) => (
   post = _.noop,
   parents = [],
   parentIndexes = []
-) => async (tree, index) =>
+) => (tree, index) =>
   pre(tree, index, parents, parentIndexes)
     .then(
       preResult =>

--- a/src/tree.js
+++ b/src/tree.js
@@ -18,7 +18,6 @@ export let walk = (next = traverse) => (
   ) ||
   post(tree, index, parents, parentIndexes)
 
-
 // async/await is so much cleaner but causes regeneratorRuntime shenanigans
 // export let findIndexedAsync = async (f, data) => {
 //   for (let key in data) {
@@ -29,8 +28,8 @@ export let walk = (next = traverse) => (
 export let findIndexedAsync = (f, data, remaining = _.toPairs(data)) => {
   if (!remaining.length) return
   let [[key, val], ...rest] = remaining
-  return Promise.resolve(f(val, key, data)).then(
-    result => result ? val : rest.length ? findIndexedAsync(f, data, rest) : undefined
+  return Promise.resolve(f(val, key, data)).then(result =>
+    result ? val : rest.length ? findIndexedAsync(f, data, rest) : undefined
   )
 }
 

--- a/src/tree.js
+++ b/src/tree.js
@@ -1,5 +1,5 @@
 import _ from 'lodash/fp'
-import { findIndexed, reduceIndexed } from './conversion'
+import { findIndexed } from './conversion'
 import { push, dotEncoder, slashEncoder } from './array'
 
 export let isTraversable = x => _.isArray(x) || _.isPlainObject(x)


### PR DESCRIPTION
- Kill promises in `findIndexedAsync` to fix regeneratorRuntime shenanigans

This is some gnarly code 😅

We're going to need to overhaul the webpack build process at some point so we can safely use `async` in `futil` 😰 

My apologies to all other `futil` contributors 😂 