### PR TITLE
Allow `walkAsync` to handle non-async traversals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.66.2
+- Allow `walkAsync` to handle non-async traversals
+
 # 1.66.1
 - Kill promises in `findIndexedAsync` to fix regeneratorRuntime shenanigans
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "futil-js",
-  "version": "1.66.1",
+  "version": "1.66.2",
   "description": "F(unctional) util(ities). Resistance is futile.",
   "main": "lib/futil-js.js",
   "scripts": {

--- a/src/tree.js
+++ b/src/tree.js
@@ -39,7 +39,7 @@ export let walkAsync = (next = traverse) => (
   parents = [],
   parentIndexes = []
 ) => (tree, index) =>
-  pre(tree, index, parents, parentIndexes)
+  Promise.resolve(pre(tree, index, parents, parentIndexes))
     .then(
       preResult =>
         preResult ||

--- a/test/tree.spec.js
+++ b/test/tree.spec.js
@@ -508,4 +508,19 @@ describe('Tree Functions', () => {
     await walkAsyncTest
     expect(tree.a.b.c.length).to.equal(4)
   })
+  it('walkAsync with sync', async () => {
+    let tree = {
+      a: {
+        b: {
+          c: [1, 2, 3],
+        },
+      },
+    }
+    let walkAsyncTest = F.walkAsync()(node => {
+      if (_.isArray(node)) node.push(4)
+    })(tree)
+    expect(tree.a.b.c.length).to.equal(3)
+    await walkAsyncTest
+    expect(tree.a.b.c.length).to.equal(4)
+  })
 })


### PR DESCRIPTION
- Allow `walkAsync` to handle non-async traversals