### PR TITLE
More lenses 🕶

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.67.0
+- Add `objectLens`
+
 # 1.66.3
 - Use deep comparison on F.{simple,}diff
 

--- a/README.md
+++ b/README.md
@@ -627,6 +627,10 @@ Returns a function that will set a lens to `false`
 `value -> arrayLens -> includeLens`
 An include lens represents membership of a value in a set. It takes a value and lens and returns a new lens - kind of like a "writeable computed" from MobX or Knockout. The view and set functions allow you to read and write a boolean value for whether or not a value is in an array. If you change to true or false, it will set the underlying array lens with a new array either without the value or with it pushed at the end.
 
+#### optionLens
+`value -> arrayLens -> optionLens`
+Like `includeLens`, `optionLens` takes a value and lens and returns a new lens. The view and set functions allow you to read and write a boolean value for whether the value passed to the `optionLens` is currently selected (meaning whether it matches the value stored in the underlying lens). Changing the `optionLens` to true "selects" its value (sets the value of the underlying lens to it). 
+
 #### domLens.value
 `lens -> {value, onChange}` Takes a lens and returns a value/onChange pair that views/sets the lens appropriately. `onChange` sets with `e.target.value` (or `e` if that path isn't present).
 Example:
@@ -657,6 +661,9 @@ Takes a value and returns a function lens for that value. Mostly used for testin
 
 ### objectLens
 Takes a value and returns a object lens for that value. Mostly used for testing and mocking purposes.
+
+### arrayLens
+Takes a value and returns an array lens for that value. Mostly used for testing and mocking purposes.
 
 ### stateLens
 `([value, setValue]) -> lens` Given the popularity of React, we decided to include this little helper that converts a `useState` hook call to a lens. Ex: `let lens = stateLens(useState(false))`. You generally won't use this directly since you can pass the `[value, setter]` pair directly to lens functions

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "futil-js",
-  "version": "1.66.3",
+  "version": "1.67.0",
   "description": "F(unctional) util(ities). Resistance is futile.",
   "main": "lib/futil-js.js",
   "scripts": {

--- a/src/lens.js
+++ b/src/lens.js
@@ -14,6 +14,13 @@ export let objectLens = val => ({
     val = x
   },
 })
+export let arrayLens = val => {
+  let result = [val]
+  result.push(x => {
+    result[0] = x
+  })
+  return result
+}
 
 // Lens Conversion
 export let fnToObj = fn => ({
@@ -50,6 +57,11 @@ export let includeLens = (value, ...lens) => ({
   get: () => _.includes(value, view(...lens)),
   // Uniq is to ensure multiple calls to set(true) don't push multiple times since this is about membership of a set
   set: x => set(_.uniq(toggleElementBy(!x, value, view(...lens))), ...lens),
+})
+
+export let optionLens = (value, ...lens) => ({
+  get: () => _.equals(value, view(...lens)),
+  set: x => set(x ? value : null, ...lens)
 })
 
 // Lens Manipulation

--- a/test/lens.spec.js
+++ b/test/lens.spec.js
@@ -19,6 +19,12 @@ describe('Lens Functions', () => {
       l.set(5)
       expect(l.get()).to.equal(5)
     })
+    it('arrayLens', () => {
+      let l = F.arrayLens(1)
+      expect(l[0]).to.equal(1)
+      l[1](5)
+      expect(l[0]).to.equal(5)
+    })
   })
   describe('Conversion', () => {
     it('fnToObj', () => {
@@ -77,6 +83,21 @@ describe('Lens Functions', () => {
       F.on(includesB)()
       expect(F.view(includesB)).to.be.true
       expect(object.arr).to.deep.equal(['a', 'c', 'd', 'b'])
+    })
+    it('optionLens', () => {
+      let object = { selected: 'a' }
+      let optionA = F.optionLens('a', 'selected', object)
+      let optionB = F.optionLens('b', 'selected', object)
+      expect(F.view(optionA)).to.be.true
+      expect(F.view(optionB)).to.be.false
+      F.on(optionB)()
+      expect(F.view(optionA)).to.be.false
+      expect(F.view(optionB)).to.be.true
+      expect(object.selected).to.equal('b')
+      F.off(optionB)()
+      expect(F.view(optionA)).to.be.false
+      expect(F.view(optionB)).to.be.false
+      expect(object.selected).to.deep.equal(null)
     })
   })
   describe('Manipulation', () => {
@@ -196,14 +217,7 @@ describe('Lens Functions', () => {
   })
   describe('additional implicit lens formats', () => {
     it('arrayLens', () => {
-      let arrayLens = val => {
-        let result = [val]
-        result.push(x => {
-          result[0] = x
-        })
-        return result
-      }
-      let lens = arrayLens(false)
+      let lens = F.arrayLens(false)
       F.on(lens)()
       expect(lens[0]).to.be.true
       F.off(lens)()


### PR DESCRIPTION
- Add `optionLens` - a higher-order lens like `includeLens`, but for selection of mutually exclusive options instead of membership in a set (ie. `optionLens` is to radio lists as `includeLens` is to checkbox lists)
- Add `arrayLens` stub (it seemed left out, since we have stubs for object and function lenses)