### PR TITLE
Upgrade to babel 7

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,8 +1,0 @@
-{
-  "presets": [
-    "env"
-  ],
-  "plugins": [
-    "transform-object-rest-spread"
-  ]
-}

--- a/babel.config.json
+++ b/babel.config.json
@@ -1,0 +1,3 @@
+{
+  "presets": ["@babel/preset-env"]
+}

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "@babel/register": "^7.8.6",
     "babel-eslint": "^10.1.0",
     "babel-loader": "^8.0.6",
-    "babel-preset-env": "^1.6.1",
     "bluebird": "^3.5.0",
     "chai": "^4.1.0",
     "chai-as-promised": "^7.1.1",

--- a/package.json
+++ b/package.json
@@ -6,13 +6,13 @@
   "scripts": {
     "build": "webpack",
     "danger": "duti",
-    "test": "babel-node ./node_modules/mocha/bin/_mocha --require ./test/init.js",
+    "test": "mocha --require @babel/register --require @babel/polyfill --require ./test/init.js",
     "test:watch": "chokidar 'src/*.js' 'test/*.js' -c 'npm t'",
     "browser": "TEST_ENV=browser karma start karma.conf.js",
     "browser:local": "karma start karma.conf.js",
-    "coverage": "nyc --require babel-core/register --require babel-polyfill --require ./test/init.js mocha test",
-    "cicoveralls": "nyc report --reporter=text-lcov --require babel-core/register --require babel-polyfill --require ./test/init.js mocha test | coveralls",
-    "cicoverage": "nyc --reporter=lcov --require babel-core/register --require babel-polyfill --require ./test/init.js mocha test --reporter json > test-results.json",
+    "coverage": "nyc --require @babel/register --require @babel/polyfill --require ./test/init.js mocha test",
+    "cicoveralls": "nyc report --reporter=text-lcov --require @babel/register --require @babel/polyfill --require ./test/init.js mocha test | coveralls",
+    "cicoverage": "nyc --reporter=lcov --require @babel/register --require @babel/polyfill --require ./test/init.js mocha test --reporter json > test-results.json",
     "lint": "eslint dangerfile.js src/*.js test/*.js",
     "lint:ci": "npm run lint -- -o lint-results.json -f json",
     "lint-fix": "eslint dangerfile.js src/*.js test/*.js --fix",
@@ -27,13 +27,8 @@
   },
   "license": "MIT",
   "dependencies": {
-    "babel-polyfill": "^6.23.0",
+    "@babel/polyfill": "^7.8.3",
     "lodash": "^4.17.4"
-  },
-  "babel": {
-    "presets": [
-      "env"
-    ]
   },
   "prettier": {
     "singleQuote": true,
@@ -41,12 +36,13 @@
     "trailingComma": "es5"
   },
   "devDependencies": {
-    "babel": "^6.5.2",
-    "babel-cli": "^6.22.2",
-    "babel-core": "^6.22.1",
-    "babel-eslint": "^8.0.0",
-    "babel-loader": "^7.0.0",
-    "babel-plugin-transform-object-rest-spread": "^6.26.0",
+    "@babel/cli": "^7.8.4",
+    "@babel/core": "^7.8.6",
+    "@babel/node": "^7.8.4",
+    "@babel/preset-env": "^7.8.6",
+    "@babel/register": "^7.8.6",
+    "babel-eslint": "^10.1.0",
+    "babel-loader": "^8.0.6",
     "babel-preset-env": "^1.6.1",
     "bluebird": "^3.5.0",
     "chai": "^4.1.0",
@@ -70,7 +66,7 @@
     "karma-webpack": "^3.0.0",
     "mocha": "^6.2.2",
     "mocha-lcov-reporter": "^1.2.0",
-    "nyc": "^12.0.1",
+    "nyc": "^15.0.0",
     "prettier": "^1.7.4",
     "read-pkg": "^5.2.0",
     "sinon": "^7.5.0",


### PR DESCRIPTION
Babel 7 was [released about 2 years ago](https://babeljs.io/blog/2018/08/27/7.0.0) and starts using the scoped packages. Since eslint and the testing work closely with babel, this should make upgrading these other libraries easier.

_Note_: should be a major bump given the changes in `babel-polyfill` can have unexpected consequences for clients.