### PR TITLE
Add lodash as a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "babel-polyfill": "^6.23.0"
   },
   "peerDependencies": {
-    "lodash": "^4.17.4"
+    "lodash": "^4.x"
   },
   "babel": {
     "presets": [

--- a/package.json
+++ b/package.json
@@ -27,7 +27,9 @@
   },
   "license": "MIT",
   "dependencies": {
-    "babel-polyfill": "^6.23.0",
+    "babel-polyfill": "^6.23.0"
+  },
+  "peerDependencies": {
     "lodash": "^4.17.4"
   },
   "babel": {


### PR DESCRIPTION
Since webpack does not bundle this dependency, the consumer is required to install **lodash** before using this library. This is most likely done so **lodash** is not duplicated accross projects.

Setting this as a peer dependency makes this nuance more explicit. As a peer dependency, **lodash** will be automatically be installed (if not already) at the root level `node_modues` same as `futil-js`.

Note that the version is lenient so both `lodash 4.17.1` and `lodash 4.17.2` get installed on the root. See [Node.js docs](https://nodejs.org/ru/blog/npm/peer-dependencies/#the-solution-peer-dependencies) for more information 