### PR TITLE
Use builtins

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,8 +1,0 @@
-{
-  "presets": [
-    "env"
-  ],
-  "plugins": [
-    "transform-object-rest-spread"
-  ]
-}

--- a/babel.config.json
+++ b/babel.config.json
@@ -1,0 +1,3 @@
+{
+  "presets": ["@babel/preset-env"]
+}

--- a/babel.config.json
+++ b/babel.config.json
@@ -1,3 +1,3 @@
 {
-  "presets": ["@babel/preset-env"]
+  "presets": [["@babel/preset-env", { "corejs": "2", "useBuiltIns": "usage" }]]
 }

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -35,8 +35,6 @@ module.exports = function(config) {
 
     // list of files / patterns to load in the browser
     files: [
-      // Load the babel polyfill
-      'node_modules/babel-polyfill/dist/polyfill.js',
       // We need to use singl entry file to avoid circular import error between
       // `aspect.js` and `conversion.js`
       'src/index.js',
@@ -80,9 +78,9 @@ module.exports = function(config) {
     // test results reporter to use
     // possible values: 'dots', 'progress'
     // available reporters: https://npmjs.org/browse/keyword/karma-reporter
-    reporters: reporters,
+    reporters,
     // Write testing results to json file.
-    jsonReporter: jsonReporter,
+    jsonReporter,
 
     // web server port
     port: 9876,
@@ -109,7 +107,7 @@ module.exports = function(config) {
     browserNoActivityTimeout: 600 * 1000,
     browserDisconnectTimeout: 60 * 1000,
     browserDisconnectTolerance: 3,
-    browsers: browsers,
+    browsers,
     customLaunchers: !local && customLaunchers,
 
     // Continuous Integration mode

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "@babel/register": "^7.8.6",
     "babel-eslint": "^10.1.0",
     "babel-loader": "^8.0.6",
-    "babel-preset-env": "^1.6.1",
     "bluebird": "^3.5.0",
     "chai": "^4.1.0",
     "chai-as-promised": "^7.1.1",

--- a/package.json
+++ b/package.json
@@ -6,13 +6,13 @@
   "scripts": {
     "build": "webpack",
     "danger": "duti",
-    "test": "babel-node ./node_modules/mocha/bin/_mocha --require ./test/init.js",
+    "test": "mocha --require @babel/register --require @babel/polyfill --require ./test/init.js",
     "test:watch": "chokidar 'src/*.js' 'test/*.js' -c 'npm t'",
     "browser": "TEST_ENV=browser karma start karma.conf.js",
     "browser:local": "karma start karma.conf.js",
-    "coverage": "nyc --require babel-core/register --require babel-polyfill --require ./test/init.js mocha test",
-    "cicoveralls": "nyc report --reporter=text-lcov --require babel-core/register --require babel-polyfill --require ./test/init.js mocha test | coveralls",
-    "cicoverage": "nyc --reporter=lcov --require babel-core/register --require babel-polyfill --require ./test/init.js mocha test --reporter json > test-results.json",
+    "coverage": "nyc --require @babel/register --require @babel/polyfill --require ./test/init.js mocha test",
+    "cicoveralls": "nyc report --reporter=text-lcov --require @babel/register --require @babel/polyfill --require ./test/init.js mocha test | coveralls",
+    "cicoverage": "nyc --reporter=lcov --require @babel/register --require @babel/polyfill --require ./test/init.js mocha test --reporter json > test-results.json",
     "lint": "eslint dangerfile.js src/*.js test/*.js",
     "lint:ci": "npm run lint -- -o lint-results.json -f json",
     "lint-fix": "eslint dangerfile.js src/*.js test/*.js --fix",
@@ -27,13 +27,8 @@
   },
   "license": "MIT",
   "dependencies": {
-    "babel-polyfill": "^6.23.0",
+    "@babel/polyfill": "^7.8.3",
     "lodash": "^4.17.4"
-  },
-  "babel": {
-    "presets": [
-      "env"
-    ]
   },
   "prettier": {
     "singleQuote": true,
@@ -41,12 +36,13 @@
     "trailingComma": "es5"
   },
   "devDependencies": {
-    "babel": "^6.5.2",
-    "babel-cli": "^6.22.2",
-    "babel-core": "^6.22.1",
-    "babel-eslint": "^8.0.0",
-    "babel-loader": "^7.0.0",
-    "babel-plugin-transform-object-rest-spread": "^6.26.0",
+    "@babel/cli": "^7.8.4",
+    "@babel/core": "^7.8.6",
+    "@babel/node": "^7.8.4",
+    "@babel/preset-env": "^7.8.6",
+    "@babel/register": "^7.8.6",
+    "babel-eslint": "^10.1.0",
+    "babel-loader": "^8.0.6",
     "babel-preset-env": "^1.6.1",
     "bluebird": "^3.5.0",
     "chai": "^4.1.0",
@@ -70,7 +66,7 @@
     "karma-webpack": "^3.0.0",
     "mocha": "^6.2.2",
     "mocha-lcov-reporter": "^1.2.0",
-    "nyc": "^12.0.1",
+    "nyc": "^15.0.0",
     "prettier": "^1.7.4",
     "read-pkg": "^5.2.0",
     "sinon": "^7.5.0",

--- a/package.json
+++ b/package.json
@@ -6,13 +6,13 @@
   "scripts": {
     "build": "webpack",
     "danger": "duti",
-    "test": "mocha --require @babel/register --require @babel/polyfill --require ./test/init.js",
+    "test": "mocha --require @babel/register --require ./test/init.js",
     "test:watch": "chokidar 'src/*.js' 'test/*.js' -c 'npm t'",
     "browser": "TEST_ENV=browser karma start karma.conf.js",
     "browser:local": "karma start karma.conf.js",
-    "coverage": "nyc --require @babel/register --require @babel/polyfill --require ./test/init.js mocha test",
-    "cicoveralls": "nyc report --reporter=text-lcov --require @babel/register --require @babel/polyfill --require ./test/init.js mocha test | coveralls",
-    "cicoverage": "nyc --reporter=lcov --require @babel/register --require @babel/polyfill --require ./test/init.js mocha test --reporter json > test-results.json",
+    "coverage": "nyc --require @babel/register --require ./test/init.js mocha test",
+    "cicoveralls": "nyc report --reporter=text-lcov --require @babel/register --require ./test/init.js mocha test | coveralls",
+    "cicoverage": "nyc --reporter=lcov --require @babel/register --require ./test/init.js mocha test --reporter json > test-results.json",
     "lint": "eslint dangerfile.js src/*.js test/*.js",
     "lint:ci": "npm run lint -- -o lint-results.json -f json",
     "lint-fix": "eslint dangerfile.js src/*.js test/*.js --fix",
@@ -27,7 +27,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@babel/polyfill": "^7.8.3",
+    "core-js": "^2.6.11",
     "lodash": "^4.17.4"
   },
   "prettier": {


### PR DESCRIPTION
See https://github.com/smartprocure/futil-js/pull/317 first. Will be a much smaller changeset when that PR is merged.

--------

Previously this library depended on a global polyfills (@babel/polyfill) to be compatible with older platforms (e.g. older browsers and node). [Babel deprecated](https://babeljs.io/docs/en/next/babel-polyfill.html) this strategy and encourages importing from `core-js` directly. With `babel-preset-env` preset, we can automatically import the required polyfills with the `useBuiltins` options.

For example previously we would get this as a babel output...
```
$ echo "Promise.resolve().finally();" > myTest.js
$ babel myTest.js
"use strict";

Promise.resolve()["finally"]();
```

Now with the `useBuiltins` option, our output looks like this:
```
$ echo "Promise.resolve().finally();" > myTest.js
$ babel myTest.js
"use strict";

require("core-js/modules/es6.promise");

require("core-js/modules/es6.object.to-string");

require("core-js/modules/es7.promise.finally");

Promise.resolve()["finally"]();
```

Including the polyfills in the library will increase the size, but solves issues with versions of `@babel/polyfill` and other globals effecting this library. Another option would be to use `babel/runtime`. See more [details on the tradeoffs](https://github.com/babel/babel/issues/7267#issuecomment-373560397).