### PR TITLE
Unwind things

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.67.0
+- Improvements to `unwind`: use `_.castArray` to avoid unwinding strings and other array-likes
+- Add `unwindArray`
+
 # 1.66.3
 - Use deep comparison on F.{simple,}diff
 

--- a/README.md
+++ b/README.md
@@ -306,7 +306,7 @@ Example: `renameProperty('a', 'b', { a: 1 }) -> { b: 1 }`
 
 ### unwind
 `k -> { k: [a, b] } -> [{ k: a }, { k: b }]`
-Just like mongo's `$unwind`: produces an array of objects from an object and one of its array-valued properties. Each object is constructed from the original object with the array value replaced by its elements. Unwinding on a nonexistent property or a property that can't be unwound returns an array containing the input object.
+Just like mongo's `$unwind`: produces an array of objects from an object and one of its array-valued properties. Each object is constructed from the original object with the array value replaced by its elements. Unwinding on a nonexistent property or a property whose value is not an array returns an empty array.
 
 ```js
 F.unwind('b', [{ a: true, b: [1, 2] }])

--- a/README.md
+++ b/README.md
@@ -305,8 +305,26 @@ Example: `renameProperty('a', 'b', { a: 1 }) -> { b: 1 }`
 
 
 ### unwind
-`'b' -> { a: true, b: [1, 2] } -> { a: true, b: 1 }, { a: true, b: 2}`
+`k -> { k: [a, b] } -> [{ k: a }, { k: b }]`
 Just like mongo's `$unwind`: produces an array of objects from an object and one of its array-valued properties. Each object is constructed from the original object with the array value replaced by its elements. Unwinding on a nonexistent property returns an empty array.
+
+```js
+F.unwind('b', [{ a: true, b: [1, 2] }])
+//=> [{ a: true, b: 1 }, { a: true, b: 2 }]
+```
+
+### unwindArray
+`k -> [{ k: [a, b] }] -> [{ k: a }, { k: b }]`
+Unwinds an array of objects instead of a single object, as you might expect if you're used to mongo's `$unwind`. Alias for `(key, data) => _.flatMap(F.unwind(key), data)`
+```js
+F.unwindArray('b', [{ a: true, b: [1, 2] }, { a: false, b: [3, 4] }])
+//=> [
+//=>  { a: true, b: 1 },
+//=>  { a: true, b: 2 },
+//=>  { a: false, b: 3 },
+//=>  { a: false, b: 4 },
+//=> ]
+```
 
 
 ### flattenObject
@@ -630,7 +648,7 @@ An include lens represents membership of a value in a set. It takes a value and 
 #### domLens.value
 `lens -> {value, onChange}` Takes a lens and returns a value/onChange pair that views/sets the lens appropriately. `onChange` sets with `e.target.value` (or `e` if that path isn't present).
 Example:
-```
+```jsx
 let Component = () => {
   let state = React.useState('')
   return <input {...F.domLens.value(state)}>

--- a/README.md
+++ b/README.md
@@ -306,7 +306,7 @@ Example: `renameProperty('a', 'b', { a: 1 }) -> { b: 1 }`
 
 ### unwind
 `k -> { k: [a, b] } -> [{ k: a }, { k: b }]`
-Just like mongo's `$unwind`: produces an array of objects from an object and one of its array-valued properties. Each object is constructed from the original object with the array value replaced by its elements. Unwinding on a nonexistent property returns an empty array.
+Just like mongo's `$unwind`: produces an array of objects from an object and one of its array-valued properties. Each object is constructed from the original object with the array value replaced by its elements. Unwinding on a nonexistent property or a property that can't be unwound returns an array containing the input object.
 
 ```js
 F.unwind('b', [{ a: true, b: [1, 2] }])

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "futil-js",
-  "version": "1.66.3",
+  "version": "1.67.0",
   "description": "F(unctional) util(ities). Resistance is futile.",
   "main": "lib/futil-js.js",
   "scripts": {

--- a/src/object.js
+++ b/src/object.js
@@ -1,6 +1,6 @@
 import _ from 'lodash/fp'
 import { dotJoinWith, zipObjectDeepWith } from './array'
-import { overNone } from './logic'
+import { overNone, ifElse } from './logic'
 import { isNotNil, isBlank } from './lang'
 import {
   reduceIndexed,
@@ -47,8 +47,19 @@ export const renameProperty = _.curry((from, to, target) =>
 
 // { x:['a','b'], y:1 } -> [{ x:'a', y:1 }, { x:'b', y:1 }] just like mongo's `$unwind`
 export const unwind = _.curry((prop, x) =>
-  _.map(y => _.set(prop, y, x), _.get(prop, x))
+  ifElse(
+    _.has(prop),
+    _.flow(
+      _.get(prop),
+      _.castArray,
+      _.map(y => _.set(prop, y, x))
+    ),
+    _.castArray,
+    x
+  )
 )
+// this one's _actually_ just like mongo's `$unwind`
+export const unwindArray = _.curry((prop, xs) => _.flatMap(unwind(prop))(xs))
 
 export const isFlatObject = overNone([_.isPlainObject, _.isArray])
 

--- a/src/object.js
+++ b/src/object.js
@@ -48,14 +48,10 @@ export const renameProperty = _.curry((from, to, target) =>
 // { x:['a','b'], y:1 } -> [{ x:'a', y:1 }, { x:'b', y:1 }] just like mongo's `$unwind`
 export const unwind = _.curry((prop, x) =>
   ifElse(
-    _.has(prop),
-    _.flow(
-      _.get(prop),
-      _.castArray,
-      _.map(y => _.set(prop, y, x))
-    ),
-    _.castArray,
-    x
+    _.isArray,
+    _.map(y => _.set(prop, y, x)),
+    _.stubArray,
+    _.get(prop, x)
   )
 )
 // this one's _actually_ just like mongo's `$unwind`

--- a/test/objects.spec.js
+++ b/test/objects.spec.js
@@ -86,33 +86,25 @@ describe('Object Functions', () => {
       { x: 'a', y: 1 },
       { x: 'b', y: 1 },
     ])
+    // should unwind undefined values
     expect(F.unwind('x', { x: ['a', undefined, 'b'], y: 1 })).to.deep.equal([
       { x: 'a', y: 1 },
       { x: undefined, y: 1 },
       { x: 'b', y: 1 },
     ])
+    // should return an empty array for keys that are not present on the object
+    expect(F.unwind('z', { x: 'foo', y: 1 })).to.deep.equal([])
+    // should also return an empty array for keys whose values can't be unwound
+    expect(F.unwind('y', { x: 'foo', y: 1 })).to.deep.equal([])
+    expect(F.unwind('y', { x: 'foo', y: undefined })).to.deep.equal([])
+    expect(F.unwind('y', { x: 'foo', y: [] })).to.deep.equal([])
     // should not unwind strings
-    expect(F.unwind('x', { x: 'foo', y: 1 })).to.deep.equal([
-      { x: 'foo', y: 1 },
-    ])
+    expect(F.unwind('x', { x: 'foo', y: 1 })).to.deep.equal([])
     // duplicate objects are fine (we don't run _.uniq on the array to unwind)
     expect(F.unwind('x', { x: [7, 7, 7], y: 1 })).to.deep.equal([
       { x: 7, y: 1 },
       { x: 7, y: 1 },
       { x: 7, y: 1 },
-    ])
-    // should always return an array for consistency, even when there's nothing
-    // to unwind at the given key
-    expect(F.unwind('y', { x: 'foo', y: 1 })).to.deep.equal([
-      { x: 'foo', y: 1 },
-    ])
-    // should handle keys that are not present on the object the same way as
-    // keys whose values can't be unwound
-    expect(F.unwind('z', { x: 'foo', y: 1 })).to.deep.equal([
-      { x: 'foo', y: 1 },
-    ])
-    expect(F.unwind('z', { x: 'foo', y: 1, z: undefined })).to.deep.equal([
-      { x: 'foo', y: 1, z: undefined },
     ])
   })
   it('unwindArray', () => {
@@ -120,6 +112,8 @@ describe('Object Functions', () => {
       F.unwindArray('x', [
         { x: ['a', 'b'], y: 1 },
         { x: ['a', 'c'], y: 2 },
+        // since `unwind` returns an empty array for non-unwindable values,
+        // this should _not_ be present on the result of `unwindArray`
         { x: 'd', y: 3 },
       ])
     ).to.deep.equal([
@@ -127,17 +121,15 @@ describe('Object Functions', () => {
       { x: 'b', y: 1 },
       { x: 'a', y: 2 },
       { x: 'c', y: 2 },
-      { x: 'd', y: 3 },
+      // { x: 'd', y: 3 },
     ])
+    // should not unwind strings
     expect(
       F.unwindArray('x', [
         { x: 'foo', y: 1 },
         { x: 'bar', y: 2 },
       ])
-    ).to.deep.equal([
-      { x: 'foo', y: 1 },
-      { x: 'bar', y: 2 },
-    ])
+    ).to.deep.equal([])
     expect(
       F.unwindArray('x', [
         { x: [7, 7, 7], y: 1 },

--- a/test/objects.spec.js
+++ b/test/objects.spec.js
@@ -82,20 +82,73 @@ describe('Object Functions', () => {
     })
   })
   it('unwind', () => {
+    expect(F.unwind('x', { x: ['a', 'b'], y: 1 })).to.deep.equal([
+      { x: 'a', y: 1 },
+      { x: 'b', y: 1 },
+    ])
+    expect(F.unwind('x', { x: ['a', undefined, 'b'], y: 1 })).to.deep.equal([
+      { x: 'a', y: 1 },
+      { x: undefined, y: 1 },
+      { x: 'b', y: 1 },
+    ])
+    // should not unwind strings
+    expect(F.unwind('x', { x: 'foo', y: 1 })).to.deep.equal([
+      { x: 'foo', y: 1 },
+    ])
+    // duplicate objects are fine (we don't run _.uniq on the array to unwind)
+    expect(F.unwind('x', { x: [7, 7, 7], y: 1 })).to.deep.equal([
+      { x: 7, y: 1 },
+      { x: 7, y: 1 },
+      { x: 7, y: 1 },
+    ])
+    // should always return an array for consistency, even when there's nothing
+    // to unwind at the given key
+    expect(F.unwind('y', { x: 'foo', y: 1 })).to.deep.equal([
+      { x: 'foo', y: 1 },
+    ])
+    // should handle keys that are not present on the object the same way as
+    // keys whose values can't be unwound
+    expect(F.unwind('z', { x: 'foo', y: 1 })).to.deep.equal([
+      { x: 'foo', y: 1 },
+    ])
+    expect(F.unwind('z', { x: 'foo', y: 1, z: undefined })).to.deep.equal([
+      { x: 'foo', y: 1, z: undefined },
+    ])
+  })
+  it('unwindArray', () => {
     expect(
-      F.unwind('x', {
-        x: ['a', 'b'],
-        y: 1,
-      })
+      F.unwindArray('x', [
+        { x: ['a', 'b'], y: 1 },
+        { x: ['a', 'c'], y: 2 },
+        { x: 'd', y: 3 },
+      ])
     ).to.deep.equal([
-      {
-        x: 'a',
-        y: 1,
-      },
-      {
-        x: 'b',
-        y: 1,
-      },
+      { x: 'a', y: 1 },
+      { x: 'b', y: 1 },
+      { x: 'a', y: 2 },
+      { x: 'c', y: 2 },
+      { x: 'd', y: 3 },
+    ])
+    expect(
+      F.unwindArray('x', [
+        { x: 'foo', y: 1 },
+        { x: 'bar', y: 2 },
+      ])
+    ).to.deep.equal([
+      { x: 'foo', y: 1 },
+      { x: 'bar', y: 2 },
+    ])
+    expect(
+      F.unwindArray('x', [
+        { x: [7, 7, 7], y: 1 },
+        { x: [1, 1], y: 2 },
+      ])
+    ).to.deep.equal([
+      { x: 7, y: 1 },
+      { x: 7, y: 1 },
+      { x: 7, y: 1 },
+      { x: 1, y: 2 },
+      { x: 1, y: 2 },
     ])
   })
   it('flattenObject', () => {


### PR DESCRIPTION
- Adds `unwindArray`, an alias for flatMapping `unwind` (this really just exists to document that `unwind` itself doesn't act on arrays, as we'd expect it to based on mongo's `$unwind` behavior)

- Updates `unwind` to call `_.castArray` so that it only unwinds arrays (not strings) - this is a potentially breaking change, but the behavior on strings wasn't documented and I'd argue that it wasn't intended, so it should be ok

- Adds extra stories for `unwind` to document edge cases (e.g. that the behavior for both nonexistent keys and keys whose values are not unwindable is to return an empty array)
