### PR TITLE
Add link to lodash/fp

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 A collection of F(unctional) Util(ities). Resistance is futile.
 
-Mostly, these are generic utilities that could conceivably be part of a library like lodash/fp, but for some reason or other are not.
+Mostly, these are generic utilities that could conceivably be part of a library like [lodash/fp](https://github.com/lodash/lodash/wiki/FP-Guide), but for some reason or other are not.
 
 # Docs
 https://smartprocure.github.io/futil-js/


### PR DESCRIPTION
This PR proposes to link to [loadash/fp](https://github.com/lodash/lodash/wiki/FP-Guide) in the initial mention of it in the README. 

-----------

Sidenote: I made a [PR](https://github.com/stoeffel/awesome-fp-js/pull/99#issue-385214301) on the official "awesome functional programming javascript" repo (4.7k+ stars) to add futil-js to the list.