### PR TITLE
Fix tree leaves edge case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.67.1
+- Fix edge case: `F.leaves()([])` and `F.leaves()({})` now return an empty array
+
 # 1.67.0
 - Improvements to `unwind`: use `_.castArray` to avoid unwinding strings and other array-likes
 - Add `unwindArray`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "futil-js",
-  "version": "1.67.0",
+  "version": "1.67.1",
   "description": "F(unctional) util(ities). Resistance is futile.",
   "main": "lib/futil-js.js",
   "scripts": {

--- a/src/lang.js
+++ b/src/lang.js
@@ -1,5 +1,5 @@
 import _ from 'lodash/fp'
-import { tree } from './tree'
+import { tree, isTraversable } from './tree'
 
 export let throws = x => {
   throw x
@@ -22,4 +22,4 @@ export let isBlank = _.overSome([
 ])
 export let isNotBlank = _.negate(isBlank)
 export let isBlankDeep = combinator => x =>
-  combinator(isBlank, tree().leaves(x))
+  isTraversable(x) ? combinator(isBlank, tree().leaves(x)) : isBlank(x)

--- a/src/tree.js
+++ b/src/tree.js
@@ -71,11 +71,23 @@ export let reduceTree = (next = traverse) =>
   })
 
 export let treeToArrayBy = (next = traverse) =>
-  _.curry((fn, tree) => reduceTree(next)((r, x) => push(fn(x), r), [], tree))
+  _.curry((fn, tree) =>
+    reduceTree(next)(
+      (r, x, key) => {
+        let result = fn(x, key)
+        return _.isUndefined(result) ? r : push(result, r)
+      },
+      [],
+      tree
+    )
+  )
 export let treeToArray = (next = traverse) => treeToArrayBy(next)(x => x)
 
 export let leaves = (next = traverse) =>
-  _.flow(treeToArray(next), _.reject(next))
+  _.flow(
+    treeToArrayBy(next)((x, k) => (_.isUndefined(k) ? k : x)),
+    _.reject(next)
+  )
 
 export let treeLookup = (next = traverse, buildIteratee = _.identity) =>
   _.curry((path, tree) =>

--- a/test/tree.spec.js
+++ b/test/tree.spec.js
@@ -115,6 +115,8 @@ describe('Tree Functions', () => {
     ).to.deep.equal([x, x.a * 2, x.b, x.b.c * 2])
   })
   it('leaves', () => {
+    expect(F.leaves()([])).to.deep.equal([])
+    expect(F.leaves()({})).to.deep.equal([])
     let x = {
       a: 1,
       b: {


### PR DESCRIPTION
Passing an empty object to `leaves` should return an empty array