### PR TITLE
Lens constructor lensProp takes default value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.68.0
+- `lensProp` takes default value
+
 # 1.67.0
 - Improvements to `unwind`: use `_.castArray` to avoid unwinding strings and other array-likes
 - Add `unwindArray`

--- a/README.md
+++ b/README.md
@@ -680,8 +680,9 @@ Takes a value and returns a object lens for that value. Mostly used for testing 
 `([value, setValue]) -> lens` Given the popularity of React, we decided to include this little helper that converts a `useState` hook call to a lens. Ex: `let lens = stateLens(useState(false))`. You generally won't use this directly since you can pass the `[value, setter]` pair directly to lens functions
 
 ### lensProp
-`propertyName -> object -> { get: () -> object.propertyName, set: propertyValue -> object.propertyName }`
-Creates an object lens for a given property on an object. `.get` returns the value at that path and `set` places a new value at that path. Supports deep paths like lodash get/set.
+`propertyName -> object -> [defaultValue] -> { get: () -> object.propertyName, set: propertyValue -> object.propertyName }`
+Creates an object lens for a given property on an object. `.get` returns the value at that path and `set` places a new value at that path. If `defaultValue` is passed, `.get` and `set` will use it if `value` is `undefined`.
+Supports deep paths like lodash get/set.
 You typically won't use this directly since it is supported implicitly.
 
 ### lensOf

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "futil-js",
-  "version": "1.67.0",
+  "version": "1.68.0",
   "description": "F(unctional) util(ities). Resistance is futile.",
   "main": "lib/futil-js.js",
   "scripts": {

--- a/src/lens.js
+++ b/src/lens.js
@@ -1,7 +1,7 @@
 import _ from 'lodash/fp'
 import { setOn } from './conversion'
 import { toggleElementBy } from './array'
-import { when } from './logic'
+import { when, whenUndefined } from './logic'
 
 // Stubs
 export let functionLens = val => (...x) => {
@@ -24,10 +24,10 @@ export let objToFn = lens => (...values) =>
   values.length ? lens.set(values[0]) : lens.get()
 
 // Lens Construction
-export let lensProp = (field, source) => ({
-  get: () => _.get(field, source), //source[field],
+export let lensProp = (field, source, def) => ({
+  get: () => whenUndefined(def, _.get(field, source)), //source[field],
   set(value) {
-    setOn(field, value, source)
+    setOn(field, whenUndefined(def, value), source)
     // source[field] = value
   },
 })

--- a/src/logic.js
+++ b/src/logic.js
@@ -21,3 +21,4 @@ export let unless = _.curry((condition, f, x) =>
 
 export let whenExists = when(exists)
 export let whenTruthy = when(Boolean)
+export let whenUndefined = when(_.isUndefined)


### PR DESCRIPTION
This is useful for form fields, where we get warnings about uncontrolled inputs. Also whenever a form field changes its value to `undefined`, the underlying field doesn't update its value