### PR TITLE
Add jsdocs inline for all documented methods

### DIFF
--- a/src/array.js
+++ b/src/array.js
@@ -12,17 +12,49 @@ let callUnlessEmptyArray = callUnlessEmpty(wrapArray)
 let dropRight = _.dropRight(1)
 let last = _.takeRight(1)
 
-// Arrays
-// ------
+/**
+ * Joins an array after compacting. Note that due to the underlying behavior of `_.curry` no default `join` value is supported -- you must pass in some string with which to perform the join.
+ * 
+ * @signature joinString -> [string1, string2, ...stringN] -> string1 + joinString + string2 +  joinString ... + stringN
+ * @tags array
+ */
 export let compactJoin = _.curry((join, x) => _.compact(x).join(join))
+
+/**
+ * Compacts and joins an array with `.`
+ * 
+ * @signature [string1, string2, ...stringN] -> string1 + '.' + string2 + '.' ... + stringN
+ * @tags array
+ */
 export let dotJoin = compactJoin('.')
+
+/**
+ * Compacts an array by the provided function, then joins it with `.`
+ * 
+ * @signature filterFunction -> [string1, string2, ...stringN] -> string1 + '.' + string2 + '.' ... + stringN
+ * @tags array
+ */
 export let dotJoinWith = fn => x => _.filter(fn, x).join('.')
+
+/**
+ * Returns an array of elements that are repeated in the array.
+ * 
+ * @signature [a] -> [a]
+ * @tags array
+ */
 export let repeated = _.flow(
   _.groupBy(e => e),
   _.filter(e => e.length > 1),
   _.flatten,
   _.uniq
 )
+
+/**
+ * Return `array` with `val` pushed.
+ * 
+ * @signature (val, array) -> array
+ * @tags array
+ */
 export let push = _.curry((val, arr) => arr.concat([val]))
 export let pushIn = _.curry((arr, val) => arr.concat([val]))
 export let pushOn = _.curry((arr, val) => {
@@ -30,6 +62,13 @@ export let pushOn = _.curry((arr, val) => {
   return arr
 })
 
+
+/**
+ * Moves a value from one index to another
+ * 
+ * @signature (from, to, array) -> array
+ * @tags array
+ */
 export let moveIndex = (from, to, arr) =>
   _.flow(_.pullAt(from), insertAtIndex(to, arr[from]))(arr)
 
@@ -38,6 +77,14 @@ let mergeRange = (x, y) => [[x[0], _.max(x.concat(y))]]
 let actuallMergeRanges = callUnlessEmptyArray((x, y) =>
   overlaps(x, y) ? [x, y] : mergeRange(x, y)
 )
+
+/**
+ * Takes any number of ranges and return the result of merging them all.
+ * 
+ * @signature ([[], [], []]) -> [[], []]
+ * @example [[0,7], [3,9], [11,15]] -> [[0,9], [11,15]]
+ * @tags array
+ */
 export let mergeRanges = _.flow(
   _.sortBy([0, 1]),
   _.reduce(
@@ -49,30 +96,90 @@ export let mergeRanges = _.flow(
   )
 )
 
-// [a, b...] -> a -> b
+/**
+ * Creates a function that takes an element of the original array as argument and returns the next element in the array (with wrapping). Note that (1) This will return the first element of the array for any argument not in the array and (2) due to the behavior of `_.curry` the created function will return a function equivalent to itself if called with no argument.
+ * 
+ * @signature [a, b...] -> a -> b
+ * @tags array
+ */
 export let cycle = _.curry((a, n) => a[(a.indexOf(n) + 1) % a.length])
 
+
+/**
+ * Creates an object from an array by generating a key/value pair for each element in the array using the key and value mapper functions.
+ * 
+ * @signature (k, v, [a]) -> { k(a): v(a) }
+ * @tags array
+ */
 export let arrayToObject = _.curry((k, v, a) =>
   _.flow(_.keyBy(k), _.mapValues(v))(a)
 )
 
-// zipObject that supports functions instead of objects
+/**
+ * A version of `_.zipObjectDeep` that supports passing a function to determine values intead of an array, which will be invoked for each key.
+ * 
+ * @tags array
+ */
 export let zipObjectDeepWith = _.curry((x, y) =>
   _.zipObjectDeep(x, _.isFunction(y) && _.isArray(x) ? _.times(y, x.length) : y)
 )
 
+
+/**
+ * Converts an array of strings into an object mapping to true. Useful for optimizing `includes`.
+ * 
+ * @signature [a, b] -> {a:true, b:true}
+ * @tags array
+ */
 export let flags = zipObjectDeepWith(_, () => true)
 
+
+/**
+ * Returns a list of all prefixes. Works on strings, too. Implementations must guarantee that the orginal argument has a length property.
+ * 
+ * @signature ['a', 'b', 'c'] -> [['a'], ['a', 'b'], ['a', 'b', 'c']]
+ * @tags array
+ */
 export let prefixes = list =>
   _.range(1, list.length + 1).map(x => _.take(x, list))
 
+
+/**
+ * Creates an object with encode and decode functions for encoding arrays as strings. The input string is used as input for join/split.
+ * 
+ * @signature string -> {encode: array -> string, decode: string -> array}
+ * @tags array
+ */
 export let encoder = separator => ({
   encode: compactJoin(separator),
   decode: _.split(separator),
 })
+
+/**
+ * An encoder using `.` as the separator
+ * 
+ * @signature { encode: ['a', 'b'] -> 'a.b', decode: 'a.b' -> ['a', 'b'] }
+ * @tags array
+ */
 export let dotEncoder = encoder('.')
+
+/**
+ * An encoder using `/` as the separator
+ * 
+ * @signature { encode: ['a', 'b'] -> 'a/b', decode: 'a/b' -> ['a', 'b'] }
+ * @tags array
+ */
 export let slashEncoder = encoder('/')
 
+
+/**
+ * Takes a predicate function and an array, and returns an array of arrays where each element has one or more elements of the original array. Similar to Haskell's [groupBy](http://zvon.org/other/haskell/Outputlist/groupBy_f.html).
+
+The predicate is called with two arguments: the current group, and the current element. If it returns truthy, the element is appended to the current group; otherwise, it's used as the first element in a new group.
+ * 
+ * @signature (([a], a) -> Boolean) -> [a] -> [[a]]
+ * @tags array
+ */
 export let chunkBy = _.curry((f, array) =>
   _.isEmpty(array)
     ? []
@@ -86,11 +193,52 @@ export let chunkBy = _.curry((f, array) =>
       )
 )
 
+
+/**
+ * Just like toggleElement, but takes an iteratee to determine if it should remove or add. This is useful for example in situations where you might have a checkbox that you want to represent membership of a value in a set instead of an implicit toggle. Used by includeLens.
+ * 
+ * @signature bool -> value -> list -> newList
+ * @tags array
+ */
 export let toggleElementBy = _.curry((check, val, arr) =>
   (callOrReturn(check, val, arr) ? _.pull : push)(val, arr)
 )
+
+/**
+ * Removes an element from an array if it's included in the array, or pushes it in if it doesn't. Immutable (so it's a clone of the array).
+ * 
+ * @signature (any, array) -> array
+ * @tags array
+ */
 export let toggleElement = toggleElementBy(_.includes)
 
+
+/**
+ * Puts the result of calling `f` in between each element of the array. `f` is a standard lodash iterator taking the value, index, and list. If `f` is not a function, it will treat `f` as the value to intersperse. See https://ramdajs.com/docs/#intersperse.
+ * 
+ * @signature f -> array -> [array[0], f(), array[n], ....)
+ * @note This works great with the `differentLast` iterator. Also, `intersperse` can be used with JSX components!
+ * @example // Example with words (toSentence is basically this flowed into a `_.join('')`):
+ * F.intersperse(differentLast(() => 'or', () => 'or perhaps'), ['first', 'second', 'third'])
+ * // ['first', 'or', 'second', 'or perhaps', 'third']
+ * 
+ * // Example with React and JSX:
+ * let results = [1, 2, 3]
+ * return <div>
+ *   <b>Results:</b>
+ *   <br/>
+ *   {
+ *     _.flow(
+ *       _.map(x => <b>{x}</b>),
+ *       F.intersperse(F.differentLast(() => ', ', () => ' and '))
+ *     )(results)
+ *   }
+ * </div>
+ * // Output:
+ * // **Results:**  
+ * // **1**, **2** and **3**.
+ * @tags array
+ */
 export let intersperse = _.curry((f, [x0, ...xs]) =>
   reduceIndexed(
     (acc, x, i) =>
@@ -100,9 +248,23 @@ export let intersperse = _.curry((f, [x0, ...xs]) =>
   )
 )
 
+
+/**
+ * Replaces an element in an array with `value` based on the boolean result of a function `fn`.
+ * 
+ * @signature (fn(array_element), value, array) -> array
+ * @tags array
+ */
 export let replaceElementBy = _.curry((f, b, arr) =>
   _.map(c => (f(c) ? b : c), arr)
 )
+
+/**
+ * Replaces all elements equal to `target` in an array with `value`.
+ * 
+ * @signature (target, value, array) -> array
+ * @tags array
+ */
 export let replaceElement = _.curry((a, b, arr) =>
   replaceElementBy(_.isEqual(a), b, arr)
 )

--- a/src/aspect.js
+++ b/src/aspect.js
@@ -1,8 +1,53 @@
+/**
+ * Aspects provide a functional oriented implementation of Aspect Oriented Programming.
+ * An aspect wraps a function and allows you run code at various points like before and after execution.
+ * Notably, aspects in this library allow you to have a shared state object between aspects and are very useful for automating things like status indicators, etc on functions.
+ * 
+ * There is a _lot_ of prior art in the javascript world, but most of it assumes a vaguely object oriented context.
+ * The implementation in `futil-js` is done in just 20 lines of code and seems to capture all of the use cases of AOP.
+ * 
+ * **Note**: To do OO style AOP with this these aspects, just use lodash's `_.update` method and optionally `boundMethod` from `futil` if `this` matters
+ * 
+ * **Caveat**: While you can and should compose (or `_.flow`) aspects together, don't put non aspects in the middle of the composition. Aspects rely on a `.state` property on the wrapped function that they propagate through, but the chain will break if a non-aspect is mixed in between. Additionally, if you need external access to the state, make sure the aspects are the outer most part of the composition so the `.state` property will be available on the result of the composition.
+ * 
+ * There are a few basic aspects included on `F.aspects` (E.g. `var loggedFunc = F.aspect(F.aspects.logs)(func)`) because they seem to be universally useful.
+ * All of the provided aspects take an `extend` function to allow customizing the state mutation method (e.g. in mobx, you'd use `extendObservable`).
+ * If null, they default to `defaultsOn` from `futil-js` - check the unit tests for example usage.
+ * @module aspect
+ */
+
 import _ from 'lodash/fp'
 import { defaultsOn, setOn } from './conversion'
 import { throws, tapError } from './lang'
 
-// Core
+/**
+ * The aspect api takes an options object and returns a function which takes a function to wrap.
+    The wrapped function will be decorated with a `state` object and is equivalent to the original function for all arguments.
+
+Options supports the following parameters:
+
+| Name | Description |
+| --- | --- |
+| `init: (state) -> ()` | A function for setting any inital state requirements. Should mutate the shared state object. |
+| `after: (result, state, params) -> ()` | Runs after the wrapped function executes and recieves the shared state and the result of the function. Can be async. |
+| `before: (params, state) -> ()` | Runs before the wrapped function executes and receves the shared state and the params passed to the wrapped function. Can be async. |
+| `onError: (error, state, params) -> ()` | Runs if the wrapped function throws an error. If you don't throw inside this, it will swallow any errors that happen. |
+| `always: (state, params) -> ()` | Runs after the wrapped function whether it throws an error or not, similar to a `Promise.catch` |
+ * 
+ * @signature {options} -> f -> aspectWrapped(f)
+ * @example let exampleAspect = aspect({
+ *   before: () => console.log('pre run'),
+ *   after: () => console.log('post run')
+ * })
+ * let f = () => console.log('run')
+ * let wrapped = exampleAspect(f)
+ * wrapped()
+ * // Logs to the console:
+ * // pre run
+ * // run
+ * // post run
+ * @tags aspect
+ */
 export let aspect = ({
   name = 'aspect',
   init = _.noop,
@@ -41,6 +86,12 @@ export let aspect = ({
   return x[name]
 }
 
+
+/**
+ * This is a synchronous version of `aspect`, for situations when it's not desirable to `await` a method you're adding aspects to. The API is the same, but things like `onError` won't work if you pass an async function to the aspect.
+ * 
+ * @tags aspect
+ */
 export let aspectSync = ({
   name = 'aspect',
   init = _.noop,
@@ -158,12 +209,59 @@ let deprecate = (subject, version, alternative) =>
   })
 
 export let aspects = {
+  /**
+   * Logs adds a `logs` array to the function state and just pushes in results on each run
+   * 
+   * @tags aspect
+   */
   logs,
+  
+  /**
+   * Captures any exceptions thrown and set it on an `error` error it puts on state
+   * 
+   * @tags aspect
+   */
   error,
+
+  /**
+   * Captures any exceptions thrown and pushes them sequentially into an `errors` array it puts on state
+   * 
+   * @tags aspect
+   */
   errors,
+  
+  /**
+   * Adds a `status` property that is set to `processing` before the wrapped function runs and `succeeded` when it's done or `failed` if it threw an exception. Also adds shortcuts on state for `processing`, `succeeded`, and `failed`, which are booleans which are based on the value of `status`. Also adds a `setStatus` method which is used internally to update these properties.
+   * 
+   * @tags aspect
+   */
   status,
+  
+  /**
+   * Utility for marking functions as deprecated - it's just a `before` with a console.warn. Takes the name of thing being deprecated, optionally deprecation version, and optionally an alternative and returns a higher order function which you can wrap deprecated methods in. This is what's used internally to mark deprecations. Includes a partial stack trace as part of the deprecation warning.
+   * 
+   * @tags aspect
+   */
   deprecate,
+  
+  /**
+   * Sets `status` to null after provided timeout (default is 500ms) elapses. If a null timeout is passed, it will never set status to null.
+   * 
+   * @tags aspect
+   */
   clearStatus,
+  
+  /**
+   * Prevents a function from running if it's state has `processing` set to true at the time of invocation
+   * 
+   * @tags aspect
+   */
   concurrency,
+  
+  /**
+   * Flows together `status`, `clearStatus`, `concurrency`, and `error`, taking `extend` and `timeout` as optional parameters to construct the aspect
+   * 
+   * @tags aspect
+   */
   command,
 }

--- a/src/collection.js
+++ b/src/collection.js
@@ -1,17 +1,38 @@
 import _ from 'lodash/fp'
 import { isTraversable } from './tree'
 
+/**
+ * Maps a flow of `f1, f2, ...fn` over a collection.
+ * 
+ * @signature [f1, f2, ...fn] -> _.map(_.flow(fn))
+ * @tags collection
+ */
 export const flowMap = (...fns) => _.map(_.flow(...fns))
+
+/**
+ * A version of `find` that also applies the predicate function to the result. Useful when you have an existing function that you want to apply to a member of a collection that you can best find by applying the same function.
+ * 
+ * @signature f -> x -> f(find(f, x))
+ * @tags collection
+ */
 export let findApply = _.curry((f, arr) => _.iteratee(f)(_.find(f, arr)))
 
-// Algebras
-// --------
-// A generic map that works for plain objects and arrays
+/**
+ * Maps a function over an iterable. Works by default for Arrays and Plain Objects.
+ * 
+ * @signature (a -> b) -> [a] -> [b]
+ * @tags collection
+ */
 export let map = _.curry((f, x) =>
   (_.isArray(x) ? _.map : _.mapValues).convert({ cap: false })(f, x)
 )
-// Map for any recursive algebraic data structure
-// defaults in multidimensional arrays and recursive plain objects
+
+/**
+ * Maps a function over a recursive iterable. Works by default for nested Arrays, nested Plain Objects and mixed nested Arrays and Plain Objects. Also works for any other iterable data type as long as two other values are sent: a mapping function, and a type checker (See the unit tests for deepMap).
+ * 
+ * @signature (a -> b) -> [a] -> [b]
+ * @tags collection
+ */
 export let deepMap = _.curry((fn, obj, _map = map, is = isTraversable) =>
   _map(e => (is(e) ? deepMap(fn, fn(e), _map, is) : e), obj)
 )
@@ -23,12 +44,27 @@ let insertAtArrayIndex = (index, val, arr) => {
   result.splice(index, 0, val)
   return result
 }
+
+/**
+ * Inserts value into an array or string at `index`
+ * 
+ * @signature (index, val, array|string) -> array|string
+ * @example (1, '123', 'hi') -> 'h123i'
+ * @tags collection
+ */
 export let insertAtIndex = _.curry((index, val, collection) =>
   _.isString(collection)
     ? insertAtStringIndex(index, val, collection)
     : insertAtArrayIndex(index, val, collection)
 )
 
+
+/**
+ * Maps `fn` over the input collection and compacts the result.
+ * 
+ * @signature (fn, collection) -> collection
+ * @tags collection
+ */
 export let compactMap = _.curry((fn, collection) =>
   _.flow(_.map(fn), _.compact)(collection)
 )

--- a/src/conversion.js
+++ b/src/conversion.js
@@ -7,25 +7,116 @@ const noCap = _.convert({ cap: false })
 
 // Flips
 // ----------
+/**
+ * lodash/fp is great, but sometimes the curry order isn't exactly what you want.
+ * 
+ * These methods provide alternative orderings that are sometimes more convenient.
+ * 
+ * The idea of `In` methods is to name them by convention, so when ever you need a method that actually takes the collection first (e.g. a `get` where the data is static but the field is dynamic), you can just add `In` to the end (such as `getIn` which takes the object first)
+ * @module convert(_In)
+ */
+
+/**
+ * Just like `_.get`, but with `{rearg: false}` so the argument order is unchanged from non fp lodash.
+ * 
+ * @tags convert(_In)
+ */
 export const getIn = noRearg.get
+
+/**
+ * Just like `_.has`, but with `{rearg: false}` so the argument order is unchanged from non fp lodash.
+ * 
+ * @tags convert(_In)
+ */
 export const hasIn = noRearg.has
+
+/**
+ * Just like `_.pick`, but with `{rearg: false}` so the argument order is unchanged from non fp lodash.
+ * 
+ * @tags convert(_In)
+ */
 export const pickIn = noRearg.pick
+
+/**
+ * Just like `_.includes`, but with `{rearg: false}` so the argument order is unchanged from non fp lodash.
+ * 
+ * @tags convert(_In)
+ */
 export const includesIn = noRearg.includes
 export const inversions = _.mapKeys(k => `${k}In`, noRearg)
 
 // Mutables
 // ----------
+/**
+ * lodash/fp likes to keep things pure, but sometimes JS can get pretty dirty.
+ * 
+ * These methods are alternatives for working with data that--for whatever the use case is--needs to be mutable
+ * 
+ * Any methods that interact with mutable data will use the `On` convention (as it is some action occuring `On` some data)
+ * @module convert(_On)
+ */
+
+/**
+ * Just like `_.extend`, but with `{mutable: true}` so it mutates.
+ * 
+ * @tags convert(_On)
+ */
 export const extendOn = mutable.extend
+
+/**
+ * Just like `_.defaults`, but with `{mutable: true}` so it mutates.
+ * 
+ * @tags convert(_On)
+ */
 export const defaultsOn = mutable.defaults
+
+/**
+ * Just like `_.merge`, but with `{mutable: true}` so it mutates.
+ * 
+ * @tags convert(_On)
+ */
 export const mergeOn = mutable.merge
+
+/**
+ * Just like `_.set`, but with `{mutable: true}` so it mutates.
+ * 
+ * @tags convert(_On)
+ */
 export const setOn = mutable.set
 // Curry required until https://github.com/lodash/lodash/issues/3440 is resolved
+
+/**
+ * Just like `_.unset`, but with `{mutable: true}` so it mutates.
+ * 
+ * @tags convert(_On)
+ */
 export const unsetOn = _.curryN(2, mutable.unset)
+
+/**
+ * Just like `_.pull`, but with `{mutable: true}` so it mutates.
+ * 
+ * @tags convert(_On)
+ */
 export const pullOn = mutable.pull
+
+/**
+ * Just like `_.update`, but with `{mutable: true}` so it mutates.
+ * 
+ * @tags convert(_On)
+ */
 export const updateOn = mutable.update
 
 // Uncaps
 // ------
+/**
+ * lodash/fp caps iteratees to one argument by default, but sometimes you need the index.
+ * 
+ * These methods are uncapped versions of lodash's methods.
+ * 
+ * Any method with uncapped iteratee arguments will use the `Indexed` convention.
+ * @module convert(_Indexed)
+ */
+
 // Un-prefixed Deprecated
 export const reduce = aspects.deprecate(
   'reduce',
@@ -43,9 +134,44 @@ export const each = aspects.deprecate(
   'eachIndexed'
 )(noCap.each)
 
+/**
+ * Just like `_.map`, but with `{cap: false}` so iteratees are not capped (e.g. indexes are passed).
+ * 
+ * @tags convert(_Indexed)
+ */
 export const mapIndexed = noCap.map
+
+/**
+ * Just like `_.find`, but with `{cap: false}` so iteratees are not capped (e.g. indexes are passed).
+ * 
+ * @tags convert(_Indexed)
+ */
 export const findIndexed = noCap.find
+
+/**
+ * Just like `_.each`, but with `{cap: false}` so iteratees are not capped (e.g. indexes are passed).
+ * 
+ * @tags convert(_Indexed)
+ */
 export const eachIndexed = noCap.each
+
+/**
+ * Just like `_.reduce`, but with `{cap: false}` so iteratees are not capped (e.g. indexes are passed).
+ * 
+ * @tags convert(_Indexed)
+ */
 export const reduceIndexed = noCap.reduce
+
+/**
+ * Just like `_.pickBy`, but with `{cap: false}` so iteratees are not capped (e.g. indexes are passed).
+ * 
+ * @tags convert(_Indexed)
+ */
 export const pickByIndexed = noCap.pickBy
+
+/**
+ * Just like `_.mapValues`, but with `{cap: false}` so iteratees are not capped (e.g. indexes are passed).
+ * 
+ * @tags convert(_Indexed)
+ */
 export const mapValuesIndexed = noCap.mapValues

--- a/src/function.js
+++ b/src/function.js
@@ -1,20 +1,54 @@
 import _ from 'lodash/fp'
 
-// (fn, a, b) -> fn(a, b)
+/**
+ * If `fn` is a function, call the function with the passed-in arguments. Otherwise, return `false`.
+ * 
+ * @signature (fn, a, b) -> fn(a, b)
+ * @tags function
+ */
 export let maybeCall = (fn, ...args) => _.isFunction(fn) && fn(...args)
-// (fn, a, b) -> fn(a, b)
+
+/**
+ * If `fn` is a function, call the function with the passed-in arguments. Otherwise, return `fn`.
+ * 
+ * @signature (fn, a, b) -> fn(a, b)
+ * @tags function
+ */
 export let callOrReturn = (fn, ...args) => (_.isFunction(fn) ? fn(...args) : fn)
-// (a, Monoid f) -> f[a] :: f a
+
+/**
+ * Binds a function of an object to it's object.
+ * 
+ * @signature (a, Monoid f) -> f[a] :: f a
+ * @tags function
+ */
 export let boundMethod = (method, object) => object[method].bind(object)
 
-// http://ramdajs.com/docs/#converge
+/**
+ * http://ramdajs.com/docs/#converge. Note that `f` is called on the array of the return values of `[g1, g2, ...gn]` rather than applied to it.
+ * 
+ * @signature (f, [g1, g2, ...gn]) -> a -> f([g1(a), g2(a), ...])
+ * @tags function
+ */
 export let converge = (converger, branches) => (...args) =>
   converger(_.over(branches)(...args))
 
 export let composeApply = (f, g) => x => f(g(x))(x)
+
+/**
+ * A combinator that combines compose and apply. `f` should be a 2 place curried function. Useful for applying comparisons to pairs defined by some one place function, e.g. `var isShorterThanFather = F.comply(isTallerThan, fatherOf)`
+ * 
+ * @signature (f, g) -> x -> f(g(x))(x)
+ * @aliases composeApply
+ * @tags function
+ */
 export let comply = composeApply
 
-// Prettier version of `defer` the one from bluebird docs
+/**
+ * Implement `defer`, ported from bluebird docs and used by debounceAsync
+ * 
+ * @tags function
+ */
 export let defer = () => {
   let resolve
   let reject
@@ -28,7 +62,12 @@ export let defer = () => {
     promise,
   }
 }
-// `_.debounce` for async functions, which require consistently returning a single promise for all queued calls
+
+/**
+ * A `_.debounce` for async functions that ensure the returned promise is resolved with the result of the execution of the actual call. Using `_.debounce` with `await` or `.then` would result in the earlier calls never returning because they're not executed - the unit tests demonstate it failing with `_.debounce`.
+ * 
+ * @tags function
+ */
 export let debounceAsync = (n, f) => {
   let deferred = defer()
   let debounced = _.debounce(n, (...args) => {
@@ -42,8 +81,18 @@ export let debounceAsync = (n, f) => {
 }
 
 let currier = f => (...fns) => _.curryN(fns[0].length, f(...fns))
-// (f1, f2, ...fn) -> f1Args1 -> f1Arg2 -> ...f1ArgN -> fn(f2(f1))
+/**
+ * Flurry is combo of flow + curry, preserving the arity of the initial function. See https://github.com/lodash/lodash/issues/3612.
+ * 
+ * @signature (f1, f2, ...fn) -> f1Arg1 -> f1Arg2 -> ...f1ArgN -> fn(f2(f1))
+ * @tags function
+ */
 export let flurry = currier(_.flow)
 
-// like _.overArgs, but on all args
+/**
+ * Returns a function that applies the mapping operation to all of the arguments of a function. Very similar to _.overArgs, but runs a single mapper on all of the args args.
+ * 
+ * @signature (mapper, fn) -> (...args) -> fn(...args.map(mapper))
+ * @tags function
+ */
 export let mapArgs = _.curry((mapper, fn) => (...x) => fn(...x.map(mapper)))

--- a/src/index.js
+++ b/src/index.js
@@ -30,10 +30,24 @@ import * as iterators from './iterators'
 
 // Math
 // ----
+
+/**
+ * Returns true if number is greater than one.
+ * 
+ * @signature number -> bool
+ * @tags math
+ */
 export const greaterThanOne = _.lt(1)
 
 // Promise
 // ----
+
+/**
+ * A utility that checks if the argument passed in is of type promise
+ * 
+ * @signature x -> bool
+ * @tags lang
+ */
 export const isPromise = obj =>
   !!obj &&
   (typeof obj === 'object' || typeof obj === 'function') &&

--- a/src/iterators.js
+++ b/src/iterators.js
@@ -1,5 +1,11 @@
 import _ from 'lodash/fp'
 
+/**
+ * Creates an iterator that handles the last item differently for use in any function that passes `(value, index, list)` (e.g. `mapIndexed`, `eachIndexed`, etc). Both the two handlers and the result are iterator functions that take `(value, index, list)`.
+ * 
+ * @signature handleItem -> handleLastItem -> iterator
+ * @tags iterators
+ */
 export let differentLast = (normalCase, lastCase) => (acc, i, list) =>
   i === list.length - 1
     ? _.iteratee(lastCase)(acc, i, list)

--- a/src/lang.js
+++ b/src/lang.js
@@ -1,25 +1,81 @@
+/**
+ * Language level utilities
+ * @module lang
+ */
+
 import _ from 'lodash/fp'
 import { tree } from './tree'
 
+/**
+ * Just throws whatever it is passed.
+ * 
+ * @tags lang
+ */
 export let throws = x => {
   throw x
 }
+
+/**
+ * Tap error will run the provided function and then throw the first argument. It's like `_.tap` for rethrowing errors.
+ * 
+ * @tags lang
+ */
 export let tapError = f => (e, ...args) => {
   f(e, ...args)
   throw e
 }
 export let isNotNil = _.negate(_.isNil)
+
+/**
+ * Negated `_.isNil`
+ * 
+ * @aliases isNotNil
+ * @tags lang
+ */
 export let exists = isNotNil
+
+/**
+ * Returns true if the input has a `length` property > 1, such as arrays, strings, or custom objects with a lenth property
+ * 
+ * @tags lang
+ */
 export let isMultiple = x => (x || []).length > 1
+
+/**
+ * A curried, flipped `_.add`. The flipping matters for strings, e.g. `F.append('a')('b') -> 'ba'`
+ * 
+ * @tags lang
+ */
 export let append = _.curry((x, y) => y + x)
 
 // True for everything except null, undefined, '', [], and {}
+
+/**
+ * Designed to determine if something has a meaningful value, like a ux version of truthiness. It's false for everything except null, undefined, '', [], and {}. Another way of describing it is that it's the same as falsiness except 0 and false are truthy and {} is falsey. Useful for implementing "required" validation rules.
+ * 
+ * @signature x -> bool
+ * @tags lang
+ */
 export let isBlank = _.overSome([
   _.isNil,
   _.isEqual(''),
   _.isEqual([]),
   _.isEqual({}),
 ])
+
+/**
+ * Opposite of `isBlank`
+ * 
+ * @signature x -> bool
+ * @tags lang
+ */
 export let isNotBlank = _.negate(isBlank)
+
+/**
+ * Recurses through an object's leaf properties and passes an array of booleans to the combinator, such as `_.some`, `_.every`, and `F.none`
+ * 
+ * @signature f -> x -> bool
+ * @tags lang
+ */
 export let isBlankDeep = combinator => x =>
   combinator(isBlank, tree().leaves(x))

--- a/src/lens.js
+++ b/src/lens.js
@@ -1,29 +1,107 @@
+/**
+ * A lens is a getter and setter pair. You use them to write code that needs to read _and_ write a value (like a method to flip a boolean switch, or a React component that reads and writes some state) without worrying about the implementation.
+ * 
+ * Functions that operate on lenses can handle a few different "shorthand" structures. This is similar to lodash's `_.iteratee` (which allows their methods to treat strings, objects, or functions as shorthand predicates)
+ * 
+ * A lens can be any of these formats:
+ * 
+ * `({ get, set })`
+ * An object with a `get` function and `set` function.
+ * Found in: MobX "boxed observables"
+ * Example Usage: `F.flip({ get, set })`
+ * 
+ * `([value, setter])`
+ * An array of the `value` and a `setter` function to change it.
+ * Found in: React's useState hook
+ * Example Usage: `F.flip([value, setter])`
+ * 
+ * `(lookup, object)`
+ * A lookup path and object pair e.g. ('key', object). The lookup path is anything you can pass to `_.get` (so nested paths with `.` or as an array are supported)
+ * Found in: MobX observable objects, native JS objects
+ * Example Usage: `F.flip(lookup, object)`
+ * 
+ * `(x => {})`
+ * A function which returns the value when called with no arguments and sets it when called with one.
+ * Found in: Knockout observables, jQuery plugin APIs
+ * Example Usage: `F.flip(x => {})`
+ * 
+ * `(getter, setter)`
+ * A getter and setter pair.
+ * Found in: Anywhere you have a getter and setter function
+ * Example Usage: `F.flip(getter, setter)`
+ * 
+ * > Note: Setter methods are generally mutable (unlike Ramda's lenses, for example).
+ * 
+ * We've included a few example "bindings" on `F.domLens`. These take a lens and return an object that's useful in a DOM context (like React or raw JS). In React terms, they're methods that generate the props you'd use to do two way binding to a lens.
+ * ![lens meme](http://giphygifs.s3.amazonaws.com/media/1jnyRP4DorCh2/giphy.gif)
+ * @module lens
+ */
+
 import _ from 'lodash/fp'
 import { setOn } from './conversion'
 import { toggleElementBy } from './array'
 import { when } from './logic'
 
 // Stubs
+
+/**
+ * Takes a value and returns a function lens for that value. Mostly used for testing and mocking purposes.
+ * 
+ * @tags lens
+ */
 export let functionLens = val => (...x) => {
   if (!x.length) return val
   val = x[0]
 }
+
+/**
+ * Takes a value and returns a object lens for that value. Mostly used for testing and mocking purposes.
+ * 
+ * @tags lens
+ */
 export let objectLens = val => ({
   get: () => val,
+
+/**
+ * Sets the value of the lens, regardless of its format
+ * 
+ * @signature propertyValue -> Lens -> object.propertyName
+ * @tags lens
+ */
   set(x) {
     val = x
   },
 })
 
 // Lens Conversion
+
+/**
+ * Converts a function lens an object lens. Mostly used for testing and mocking purposes.
+ * 
+ * @tags lens
+ */
 export let fnToObj = fn => ({
   get: fn,
   set: fn,
 })
+
+/**
+ * Converts an object lens to a function lens. Mostly used for testing and mocking purposes.
+ * 
+ * @tags lens
+ */
 export let objToFn = lens => (...values) =>
   values.length ? lens.set(values[0]) : lens.get()
 
 // Lens Construction
+
+/**
+ * Creates an object lens for a given property on an object. `.get` returns the value at that path and `set` places a new value at that path. Supports deep paths like lodash get/set.
+You typically won't use this directly since it is supported implicitly.
+ * 
+ * @signature propertyName -> object -> { get: () -> object.propertyName, set: propertyValue -> object.propertyName }
+ * @tags lens
+ */
 export let lensProp = (field, source) => ({
   get: () => _.get(field, source), //source[field],
   set(value) {
@@ -36,6 +114,12 @@ export let lensProp = (field, source) => ({
 // in some edge cases like trying to lens state coming from an inject function
 // in the mobx library. It would inadvertently cause the inject to re-run.
 // Using reduce here alleviates that issue.
+
+/**
+ * Takes an object and returns an object with lenses at the values of each path. Basically `mapValues(lensProp)`. Typically you would use the implicit `(key, object)` format instead.
+ * 
+ * @tags lens
+ */
 export let lensOf = object =>
   _.reduce(
     (res, key) => {
@@ -46,6 +130,13 @@ export let lensOf = object =>
     _.keys(object)
   )
 
+
+/**
+ * An include lens represents membership of a value in a set. It takes a value and lens and returns a new lens - kind of like a "writeable computed" from MobX or Knockout. The view and set functions allow you to read and write a boolean value for whether or not a value is in an array. If you change to true or false, it will set the underlying array lens with a new array either without the value or with it pushed at the end.
+ * 
+ * @signature value -> arrayLens -> includeLens
+ * @tags lens
+ */
 export let includeLens = (value, ...lens) => ({
   get: () => _.includes(value, view(...lens)),
   // Uniq is to ensure multiple calls to set(true) don't push multiple times since this is about membership of a set
@@ -63,16 +154,60 @@ let construct = (...args) =>
     : when(_.isArray, stateLens)(args[0])
 
 let read = lens => (lens.get ? lens.get() : lens())
+
+/**
+ * Gets the value of the lens, regardless of its format
+ * 
+ * @signature Lens -> object.propertyName
+ * @tags lens
+ */
 export let view = (...lens) => read(construct(...lens))
+
+/**
+ * Returns a function that gets the value of the lens, regardless of its format
+ * 
+ * @signature Lens -> (() -> object.propertyName)
+ * @tags lens
+ */
 export let views = (...lens) => () => view(...lens)
 let write = (val, lens) => (lens.set ? lens.set(val) : lens(val))
 export let set = _.curryN(2, (val, ...lens) => write(val, construct(...lens)))
+
+/**
+ * Creates a function that will set a lens with the provided value
+ * 
+ * @tags lens
+ */
 export let sets = _.curryN(2, (val, ...lens) => () => set(val, ...lens))
+
+/**
+ * Takes an iteratee and lens and creates a function that will set a lens with the result of calling the iteratee with the provided value
+ * 
+ * @tags lens
+ */
 export let setsWith = _.curry((f, ...lens) => x =>
   set(_.iteratee(f)(x), ...lens)
 )
+
+/**
+ * Takes a lens and negates its value
+ * 
+ * @tags lens
+ */
 export let flip = (...lens) => () => set(!view(...lens), ...lens)
+
+/**
+ * Returns a function that will set a lens to `true`
+ * 
+ * @tags lens
+ */
 export let on = sets(true)
+
+/**
+ * Returns a function that will set a lens to `false`
+ * 
+ * @tags lens
+ */
 export let off = sets(false)
 
 // Lens Consumption
@@ -84,19 +219,72 @@ let binding = (value, getEventValue) => (...lens) => ({
 // Dom events have relevent fields on the `target` property of event objects
 let targetBinding = field =>
   binding(field, when(_.hasIn(`target.${field}`), _.get(`target.${field}`)))
+
 export let domLens = {
+  /**
+   * Takes a lens and returns a value/onChange pair that views/sets the lens appropriately. `onChange` sets with `e.target.value` (or `e` if that path isn't present).
+   * 
+   * @signature lens -> {value, onChange}
+   * @example let Component = () => {
+   *   let state = React.useState('')
+   *   return <input {...F.domLens.value(state)}>
+   * }
+   * @tags lens
+   */
   value: targetBinding('value'),
+
+  /**
+   * Creates an includeLens and maps view to checked and set to `onChange` (set with `e.target.checked` or `e` if that path isn't present)
+   * 
+   * @signature (value, lens) -> {checked, onChange}
+   * @tags lens
+   */
   checkboxValues: _.flow(includeLens, targetBinding('checked')),
+
+  /**
+   * Takes a lens and returns on onMouseEnter which calls `on` on the lens and onMouseLeave which calls `off`. Models a mapping of "hovering" to a boolean.
+   * 
+   * @signature lens -> { onMouseEnter, onMouseLeave }
+   * @tags lens
+   */
   hover: (...lens) => ({
     onMouseEnter: on(...lens),
     onMouseLeave: off(...lens),
   }),
+
+  /**
+   * Takes a lens and returns on onFocus which calls `on` on the lens and onBlur which calls `off`. Models a mapping of "focusing" to a boolean.
+   * 
+   * @signature lens -> { onFocus, onBlur }
+   * @tags lens
+   */
   focus: (...lens) => ({
     onFocus: on(...lens),
     onBlur: off(...lens),
   }),
+
+  /**
+   * Utility for building lens consumers like `value` and `checkboxValues`
+   * 
+   * @signature field -> lens -> {[field], onChange}
+   * @tags lens
+   */
   targetBinding,
+
+  /**
+   * Even more generic utility than targetBinding which uses `getEventValue` to as the function for a setsWith which is mapped to `onChange`.
+   * 
+   * @signature (field, getValue) -> lens -> {[field], onChange}
+   * @tags lens
+   */
   binding,
 }
 
+
+/**
+ * Given the popularity of React, we decided to include this little helper that converts a `useState` hook call to a lens. Ex: `let lens = stateLens(useState(false))`. You generally won't use this directly since you can pass the `[value, setter]` pair directly to lens functions
+ * 
+ * @signature ([value, setValue]) -> lens
+ * @tags lens
+ */
 export let stateLens = ([value, set]) => ({ get: () => value, set })

--- a/src/logic.js
+++ b/src/logic.js
@@ -2,22 +2,58 @@ import _ from 'lodash/fp'
 import { callOrReturn } from './function'
 import { exists } from './lang'
 
-// ([f, g]) -> !f(x) && !g(x)
+/**
+ * Creates a function that checks if none of the array of predicates passed in returns truthy for `x`
+ * 
+ * @signature ([f1, f2, ...fn]) -> !f1(x) && !f2(x) && ...!fn(x)
+ * @tags logic
+ */
 export const overNone = _.flow(_.overSome, _.negate)
 
 let boolIteratee = x => (_.isBoolean(x) || _.isNil(x) ? () => x : _.iteratee(x))
-// Port from Ramda
+
+/**
+ * http://ramdajs.com/docs/#ifElse. The transform function T supports passing a boolean for `condition` as well as any valid argument of `_.iteratee`, e.g. `myBool = applyTest(x); F.ifElse(myBool, doSomething, doSomethingElse);`
+ * 
+ * @signature (condition, onTrue, onFalse, x) -> (T(condition)(x) ? onTrue(x) : onFalse(x))
+ * @tags logic
+ */
 export let ifElse = _.curry((condition, onTrue, onFalse, x) =>
   boolIteratee(condition)(x)
     ? callOrReturn(onTrue, x)
     : callOrReturn(onFalse, x)
 )
+
+/**
+ * http://ramdajs.com/docs/#when. `T` extends `_.iteratee` as above.
+ * 
+ * @signature (condition, onTrue, x) -> (T(condition)(x) ? onTrue(x) : _.identity(x))
+ * @tags logic
+ */
 export let when = _.curry((condition, t, x) =>
   ifElse(condition, t, _.identity, x)
 )
+
+/**
+ * http://ramdajs.com/docs/#unless. `T` extends `_.iteratee` as above.
+ * 
+ * @signature (condition, onFalse, x) -> (T(condition)(x) ? _.identity(x) : onFalse(x))
+ * @tags logic
+ */
 export let unless = _.curry((condition, f, x) =>
   ifElse(condition, _.identity, f, x)
 )
 
+/**
+ * `when` curried with `Boolean`
+ * 
+ * @tags logic
+ */
+ export let whenTruthy = when(Boolean)
+
+/**
+ * `when` curried with `exists`
+ * 
+ * @tags logic
+ */
 export let whenExists = when(exists)
-export let whenTruthy = when(Boolean)

--- a/src/object.js
+++ b/src/object.js
@@ -15,37 +15,95 @@ import { aspects } from './aspect'
 import { mapArgs } from './function'
 const noCap = _.convert({ cap: false })
 
-// (k, v) -> {k: v}
+/**
+ * Creates an object with a key and value.
+ * 
+ * @signature (k, v) -> {k: v}
+ * @tags object
+ */
 export const singleObject = _.curry((key, value) => ({ [key]: value }))
+
+/**
+ * Flipped version of `singleObject`.
+ * 
+ * @signature (v, k) -> {k: v}
+ * @tags object
+ */
 export const singleObjectR = _.flip(singleObject)
 
-// Formerly objToObjArr
-// ({a, b}) -> [{a}, {b}]
+/**
+ * Breaks an object into an array of objects with one key each.
+ * 
+ * @signature ({a, b}) -> [{a}, {b}]
+ * @tags object
+ */
 export const chunkObject = value =>
   _.isArray(value) ? value : _.map(_.spread(singleObject), _.toPairs(value))
 
-// Remove properties with falsey values: ({ a: 1, b: null, c: false}) -> {a:1}
+/**
+ * Remove properties with falsey values.
+ * 
+ * @example ({ a: 1, b: null, c: false }) -> {a:1}
+ * @tags object
+ */
 export const compactObject = _.pickBy(_.identity)
 
+/**
+ * Check if the variable is an empty object (`{}`).
+ * 
+ * @tags object
+ */
 export const isEmptyObject = _.isEqual({})
 
+/**
+ * Check if the variable is **not** an empty object (`{}`).
+ * 
+ * @tags object
+ */
 export const isNotEmptyObject = _.negate(isEmptyObject)
 
-// { a:1, b:{}, c:2 } -> { a:1, c:2 }
+/**
+ * Omit properties whose values are empty objects.
+ * 
+ * @note (*TODO* rename to `omitEmptyObjects`)
+ * @example { a:1, b:{}, c:2 } -> {a:1, c:2}
+ * @tags object
+ */
 export const stripEmptyObjects = _.pickBy(isNotEmptyObject)
 
 // const crazyBS = (f, g) => (a, b) => f(a)(g(b))
 
 // { a: { b: 1, c: 2 } }, [ 'b' ] -> { a: { b: 1 } }
+
+/**
+ * *TODO*
+ * 
+ * @tags object
+ */
 export const pickInto = (map, source) => _.mapValues(pickIn(source), map)
 
+
+/**
+ * Rename a property on an object.
+ * 
+ * @signature sourcePropertyName -> targetPropertyName -> sourceObject -> sourceObject
+ * @example renameProperty('a', 'b', { a: 1 }) -> { b: 1 }
+ * @tags object
+ */
 export const renameProperty = _.curry((from, to, target) =>
   _.has(from, target)
     ? _.flow(x => _.set(to, _.get(from, x), x), _.unset(from))(target)
     : target
 )
 
-// { x:['a','b'], y:1 } -> [{ x:'a', y:1 }, { x:'b', y:1 }] just like mongo's `$unwind`
+/**
+ * Just like mongo's `$unwind`: produces an array of objects from an object and one of its array-valued properties. Each object is constructed from the original object with the array value replaced by its elements. Unwinding on a nonexistent property or a property whose value is not an array returns an empty array.
+ * 
+ * @signature k -> { k: [a, b] } -> [{ k: a }, { k: b }]
+ * @example F.unwind('b', [{ a: true, b: [1, 2] }])
+ *       //=> [{ a: true, b: 1 }, { a: true, b: 2 }]
+ * @tags object
+ */
 export const unwind = _.curry((prop, x) =>
   ifElse(
     _.isArray,
@@ -54,12 +112,30 @@ export const unwind = _.curry((prop, x) =>
     _.get(prop, x)
   )
 )
-// this one's _actually_ just like mongo's `$unwind`
+
+/**
+ * Unwinds an array of objects instead of a single object, as you might expect if you're used to mongo's `$unwind`. Alias for `(key, data) => _.flatMap(F.unwind(key), data)`
+ * 
+ * @signature k -> [{ k: [a, b] }] -> [{ k: a }, { k: b }]
+ * @example F.unwindArray('b', [{ a: true, b: [1, 2] }, { a: false, b: [3, 4] }])
+ * //=> [
+ * //=>  { a: true, b: 1 },
+ * //=>  { a: true, b: 2 },
+ * //=>  { a: false, b: 3 },
+ * //=>  { a: false, b: 4 },
+ * //=> ]
+ * @tags object
+ */
 export const unwindArray = _.curry((prop, xs) => _.flatMap(unwind(prop))(xs))
 
 export const isFlatObject = overNone([_.isPlainObject, _.isArray])
 
-// { a: { b: { c: 1 } } } => { 'a.b.c' : 1 }
+/**
+ * Flatten an object with the paths for keys.
+ * 
+ * @example { a: { b: { c: 1 } } } => { 'a.b.c' : 1 }
+ * @tags object
+ */
 export const flattenObject = (input, paths) =>
   reduceIndexed(
     (output, value, key) =>
@@ -74,38 +150,79 @@ export const flattenObject = (input, paths) =>
     input
   )
 
-// { 'a.b.c' : 1 } => { a: { b: { c: 1 } } }
+/**
+ * Unlatten an object with the paths for keys.
+ * 
+ * @example { 'a.b.c' : 1 } => { a: { b: { c: 1 } } }
+ * @tags object
+ */
 export const unflattenObject = x => _.zipObjectDeep(_.keys(x), _.values(x))
 
-// Returns true if object keys are only elements from signature list (but does not require all signature keys to be present)
+/**
+ * Returns true if object keys are only elements from signature list. (but does not require all signature keys to be present)
+ * 
+ * @tags object
+ */
 export const matchesSignature = _.curry(
   (signature, value) =>
     _.isObject(value) && !_.difference(_.keys(value), signature).length
 )
 
-// `_.matches` that returns true if one or more of the conditions match instead of all
+/**
+ * Similar to `_.matches`, except it returns true if 1 or more object properties match instead of all of them. See https://github.com/lodash/lodash/issues/3713.
+ * 
+ * @tags object
+ */
 export const matchesSome = _.flow(chunkObject, _.map(_.matches), _.overSome)
 
-// Checks if a property deep in a given item equals to a given value
+/**
+ * Checks if an object's property is equal to a value.
+ * 
+ * @tags object
+ */
 export const compareDeep = _.curry(
   (path, item, value) => _.get(path, item) === value
 )
 
-//Depreacted in favor of _.update version from lodash
+/**
+ * _Deprecated in favor of lodash `update`_ Applies a map function at a specific path
+ * 
+ * @example mapProp(double, 'a', {a: 2, b: 1}) -> {a: 4, b: 1}
+ * @deprecated 1.46.0
+ * @tags object
+ */
 export const mapProp = aspects.deprecate(
   'mapProp',
   '1.46.0',
   '_.update'
 )(noCap.update)
 
-// `_.get` that returns the target object if lookup fails
+/**
+ * `_.get` that returns the target object if lookup fails
+ * 
+ * @tags object
+ */
 export let getOrReturn = _.curry((prop, x) => _.getOr(x, prop, x))
-// `_.get` that returns the prop if lookup fails
+
+/**
+ * `_.get` that returns the prop if lookup fails
+ * 
+ * @tags object
+ */
 export let alias = _.curry((prop, x) => _.getOr(prop, prop, x))
-// flipped alias
+
+/**
+ * Flipped `alias`
+ * 
+ * @tags object
+ */
 export let aliasIn = _.curry((x, prop) => _.getOr(prop, prop, x))
 
-// A `_.get` that takes an array of paths and returns the value at the first path that matches
+/**
+ * A `_.get` that takes an array of paths (or functions to return values) and returns the value at the first path that matches. Similar to `_.overSome`, but returns the first result that matches instead of just truthy (and supports a default value)
+ * 
+ * @tags object
+ */
 export let cascade = _.curryN(2, (paths, obj, defaultValue) =>
   _.flow(
     findApply(x => x && _.iteratee(x)(obj)),
@@ -113,23 +230,56 @@ export let cascade = _.curryN(2, (paths, obj, defaultValue) =>
   )(paths)
 )
 
-// Flipped cascade
+/**
+ * Flipped cascade
+ * 
+ * @tags object
+ */
 export let cascadeIn = _.curryN(2, (obj, paths, defaultValue) =>
   cascade(paths, obj, defaultValue)
 )
-// A `_.get` that takes an array of paths and returns the first path that matched
+
+/**
+ * A `_.get` that takes an array of paths and returns the first path that matched
+ * 
+ * @tags object
+ */
 export let cascadeKey = _.curry((paths, obj) => _.find(getIn(obj), paths))
-// A `_.get` that takes an array of paths and returns the first path that exists
+
+/**
+ * A `_.get` that takes an array of paths and returns the first path that exists
+ * 
+ * @tags object
+ */
 export let cascadePropKey = _.curry((paths, obj) => _.find(hasIn(obj), paths))
-// A `_.get` that takes an array of paths and returns the first value that has an existing path
+
+/**
+ * A `_.get` that takes an array of paths and returns the first value that has an existing path
+ * 
+ * @tags object
+ */
 export let cascadeProp = _.curry((paths, obj) =>
   _.get(cascadePropKey(paths, obj), obj)
 )
 
+/**
+ * Opposite of `_.keyBy`. Creates an array from an object where the key is merged into the values keyed by `newKey`.
+ * 
+ * @signature newKey -> {a:x, b:y} -> [{...x, newKey: a}, {...y, newKey: b}]
+ * @note Passing a falsy value other than `undefined` for `newKay` will result in each object key being pushed into its corresponding return array member with itself as value, e.g. `F.unkeyBy('')({ a: { status: true}, b: { status: false }) -> [{ status: true, a: 'a' }, { status: false, b: 'b' }]`. Passing `undefined` will return another instance of F.unkeyBy.
+ * @example F.unkeyBy('_key')({ a: { status: true}, b: { status: false }) -> [{ status: true, _key: 'a' }, { status: false, _key: 'b' }]
+ * @tags object
+ */
 export let unkeyBy = _.curry((keyName, obj) =>
   mapIndexed((val, key) => _.extend(val, { [keyName || key]: key }))(obj)
 )
 
+/**
+ * Produces a simple flattened (see `flattenObject`) diff between two objects. For each (flattened) key, it produced a `from` and a `to` value. Note that this will omit any values that are not present in the deltas object.
+ * 
+ * @signature (from, to) -> simpleDiff
+ * @tags object
+ */
 export let simpleDiff = (original, deltas) => {
   let o = flattenObject(original)
   return _.flow(
@@ -138,8 +288,22 @@ export let simpleDiff = (original, deltas) => {
     _.omitBy(x => _.isEqual(x.from, x.to))
   )(deltas)
 }
+
+/**
+ * Same as `simpleDiff`, but produces an array of `{ field, from, to }` objects instead of `{ field: { from, to } }`
+ * 
+ * @signature (from, to) -> [simpleDiffChanges]
+ * @tags object
+ */
 export let simpleDiffArray = _.flow(simpleDiff, unkeyBy('field'))
 
+/**
+ * Same as `simpleDiff`, but also takes in count deleted properties.
+ * 
+ * @signature (from, to) -> diff
+ * @note We're considering not maintaining this in the long term, so you might probably have more success with any existing library for this purpose.
+ * @tags object
+ */
 export let diff = (original, deltas) => {
   let o = flattenObject(original)
   let d = flattenObject(deltas)
@@ -148,9 +312,21 @@ export let diff = (original, deltas) => {
     _.omitBy(x => _.isEqual(x.from, x.to))
   )(_.merge(o, d))
 }
+
+/**
+ * Same as `simpleDiffArray`, but also takes in count deleted properties.
+ * 
+ * @signature (from, to) -> [diffChanges]
+ * @note We're considering not maintaining this in the long term, so you might probably have more success with any existing library for this purpose.
+ * @tags object
+ */
 export let diffArray = _.flow(diff, unkeyBy('field'))
 
-// A `_.pick` that mutates the object
+/**
+ * A `_.pick` that mutates the object
+ * 
+ * @tags object
+ */
 export let pickOn = (paths = [], obj = {}) =>
   _.flow(
     _.keys,
@@ -164,55 +340,138 @@ export let pickOn = (paths = [], obj = {}) =>
 let mergeArrays = (objValue, srcValue) =>
   _.isArray(objValue) ? objValue.concat(srcValue) : undefined
 
-// Straight from the lodash docs
+/**
+ * Like `_.mergeAll`, but concats arrays instead of replacing. This is basically the example from the lodash `mergeAllWith` docs.
+ * 
+ * @tags object
+ */
 export let mergeAllArrays = _.mergeAllWith(mergeArrays)
-// { a: [x, y, z], b: [x] } -> { x: [a, b], y: [a], z: [a] }
+
+/**
+ * Similar to `_.invert`, but expands arrays instead of converting them to strings before making them keys.
+ * 
+ * @signature { a: [x, y, z], b: [x] } -> { x: [a, b], y: [a], z: [a] }
+ * @tags object
+ */
 export let invertByArray = _.flow(
   mapIndexed((arr, key) => zipObjectDeepWith(arr, () => [key])),
   mergeAllArrays
 )
 
-// key -> { a: { x: 1 }, b: { y: 2 } } -> { a: { x: 1, key: 'a' }, b: { y: 2, key: 'b' } }
+/**
+ * Iterates over object properties and stamps their keys on the values in the field name provided.
+ * 
+ * @signature key -> { a: { x: 1 }, b: { y: 2 } } -> { a: { x: 1, key: 'a' }, b: { y: 2, key: 'b' } }
+ * @tags object
+ */
 export const stampKey = _.curry((key, x) =>
   mapValuesIndexed((val, k) => ({ ...val, [key]: k }), x)
 )
 
+
+/**
+ * `_.omitBy` using `_.isNil` as function argument.
+ * 
+ * @tags object
+ */
 export let omitNil = x => _.omitBy(_.isNil, x)
+
+/**
+ * `_.omitBy` using `_.isNull` as function argument.
+ * 
+ * @tags object
+ */
 export let omitNull = x => _.omitBy(_.isNull, x)
+
+/**
+ * `_.omitBy` using `F.isBlank` as function argument.
+ * 
+ * @tags object
+ */
 export let omitBlank = x => _.omitBy(isBlank, x)
+
+/**
+ * `_.omitBy` using `_.isEmpty` as function argument.
+ * 
+ * @tags object
+ */
 export let omitEmpty = x => _.omitBy(_.isEmpty, x)
 
-// ([f, g]) -> (x, y) -> {...f(x, y), ...g(x, y)}
+/**
+ * Composition of `_.over` and `_.mergeAll`. Takes an array of functions and an arbitrary number of arguments, calls each function with those arguments, and merges the results. Can be called with `mergeOverAll([f, g], x, y)` or `mergeOverAll([f, g])(x, y)`.
+ * 
+ * @signature ([f, g], ...args) -> {...f(...args), ...g(...args)}
+ * @note For functions that do not return objects, `_.merge`'s behavior is followed: for strings and arrays, the indices will be converted to keys and the result will be merged, and for all other primitives, nothing will be merged.
+ * @tags object
+ */
 export let mergeOverAll = _.curryN(2, (fns, ...x) =>
   _.flow(_.over(fns), _.mergeAll)(...x)
 )
 
-// customizer -> ([f, g]) -> (x, y) -> {...f(x, y), ...g(x, y)}
+/**
+ * A customizable `mergeOverAll` that takes a function of the form `(objValue, srcValue) -> newValue` as its first argument; see [`_.mergeWith`](https://lodash.com/docs/latest#mergeWith). Both the customizer and array of functions can be partially applied.
+ * 
+ * @signature (customizer, [f, g], ...args) -> {...f(...args), ...g(...args)}
+ * @tags object
+ */
 export let mergeOverAllWith = _.curryN(3, (customizer, fns, ...x) =>
   _.flow(_.over(fns), _.mergeAllWith(customizer))(...x)
 )
 
-// ([f, g]) -> (x, y) -> {...f(x, y), ...g(x, y)}
+/**
+ * A customized `mergeOverAll` that applies the array-merging behavior of `mergeAllArrays`.
+ * 
+ * @signature ([f, g], ...args) -> {...f(...args), ...g(...args)}
+ * @tags object
+ */
 export let mergeOverAllArrays = mergeOverAllWith(mergeArrays)
 
-// (x -> y) -> k -> {k: x} -> y
+/**
+ * Like `_.get`, but accepts a customizer function which is called on the value to transform it before it is returned. Argument order is `(customizer, path, object)`.
+ * 
+ * @signature (x -> y) -> k -> {k: x} -> y
+ * @tags object
+ */
 export let getWith = _.curry((customizer, path, object) =>
   customizer(_.get(path, object))
 )
 
-// ({a} -> {b}) -> {a} -> {a, b}
+/**
+ * Accepts a transform function and an object. Returns the result of applying the transform function to the object, merged onto the original object. `expandObject(f, obj)` is equivalent to `mergeOverAll([_.identity, f], obj)`.
+ * 
+ * @signature (transform: obj -> newObj) -> obj -> { ...obj, ...newObj }
+ * @tags object
+ */
 export let expandObject = _.curry((transform, obj) => ({
   ...obj,
   ...transform(obj),
 }))
 
-// k -> (a -> {b}) -> {k: a} -> {a, b}
+/**
+ * Expands an object by transforming the value at a single key into a new object, and merging the result with the original object. Similar to `expandObject`, but the argument order is `(key, transform, object)`, and the transform function is called on the value at that key instead of on the whole object.
+ * 
+ * @signature key -> (transform: x -> newObj) -> (obj: { key: x }) -> { ...obj, ...newObj }
+ * @tags object
+ */
 export let expandObjectBy = _.curry((key, fn, obj) =>
   expandObject(getWith(fn, key))(obj)
 )
 
+/**
+ * Takes two objects and returns the keys they have in common
+ * 
+ * @signature (x, y) -> [keys]
+ * @tags object
+ */
 export let commonKeys = _.curryN(2, mapArgs(_.keys, _.intersection))
 let findKeyIndexed = _.findKey.convert({ cap: false })
+
+/**
+ * Takes two objects and returns the first key in `y` that x also has
+ * 
+ * @signature (x, y) -> key
+ * @tags object
+ */
 export let firstCommonKey = _.curry((x, y) =>
   findKeyIndexed((val, key) => _.has(key, x), y)
 )

--- a/src/string.js
+++ b/src/string.js
@@ -7,18 +7,58 @@ import { differentLast } from './iterators'
 export const wrap = (pre, post, content) =>
   (pre || '') + content + (post || pre || '')
 export const quote = _.partial(wrap, ['"', '"'])
+
+/**
+ * Wraps a string in parenthesis.
+ * 
+ * @signature 'asdf' -> '(asdf)'
+ * @tags string
+ */
 export const parens = _.partial(wrap, ['(', ')'])
 export const concatStrings = _.flow(_.compact, _.map(_.trim), _.join(' '))
+
+/**
+ * Maps `_.trim` through all the strings of a given object or array.
+ * 
+ * @tags string
+ */
 export const trimStrings = map(when(_.isString, _.trim))
 
 // _.startCase does the trick, deprecate it!
+/**
+ * Converts strings like variable names to labels (generally) suitable for GUIs, including support for acronyms and numbers. It's basically `_.startCase` with acronym and number support.
+ * 
+ * @signature string -> string
+ * @tags string
+ */
 export let autoLabel = _.startCase
+
+/**
+ * Creates a `{value, label}` which applies `autoLabel` the string parameter on puts it on the label property, with the original on the value property. You can also pass in an object with value or with both value and label.
+ * 
+ * @signature string -> {value:string, label:string}
+ * @tags string
+ */
 export let autoLabelOption = a => ({
   value: when(_.isUndefined, a)(a.value),
   label: a.label || autoLabel(when(_.isUndefined, a)(a.value)),
 })
+
+/**
+ * Applies `autoLabelOption` to a collection. Useful for working with option lists like generating select tag options from an array of strings.
+ * 
+ * @signature [string] -> [{value:string, label:string}]
+ * @tags string
+ */
 export let autoLabelOptions = _.map(autoLabelOption)
 
+/**
+ * Just like `toSentence`, but with the ability to override the `separator` and `lastSeparator`
+ * 
+ * @signature (separator, lastSeparator, array) => string
+ * @example (' - ', ' or ', ['a', 'b', 'c']) -> 'a - b or c'
+ * @tags string
+ */
 export let toSentenceWith = _.curry((separator, lastSeparator, array) =>
   _.flow(
     intersperse(
@@ -31,9 +71,29 @@ export let toSentenceWith = _.curry((separator, lastSeparator, array) =>
   )(array)
 )
 
+/**
+ * Joins an array into a human readable string. See https://github.com/epeli/underscore.string#tosentencearray-delimiter-lastdelimiter--string
+ * 
+ * @signature array => string
+ * @example ['a', 'b', 'c'] -> 'a, b and c'
+ * @tags string
+ */
 export let toSentence = toSentenceWith(', ', ' and ')
 
-// ((array -> object), array) -> string -> string
+/**
+ * Allows passing a "cachizer" function (`array -> object`) to override the way `uniqueString`'s initial array is converted into a cache object. Can be curried to create a custom `uniqueString` function, eg: `let myUniqueString = uniqueStringWith(myFunc)`
+
+Like `uniqueString`, the resulting deduplication function exposes `cache` and `clear()` properties.
+ * 
+ * @signature (fn, array) -> string -> string
+ * @example let uniqueStringStripDigits = uniqueStringWith(
+ *   _.countBy(_.replace(/(\d+)$/, ''))
+ * )
+ * let dedupe = uniqueStringStripDigits(['foo', 'foo42', 'foo3000'])
+ * dedupe('foo')  //-> 'foo3'
+ * uniqueStringWith(_.identity, dedupe.cache)('foo')  //-> 'foo4'
+ * @tags string
+ */
 export let uniqueStringWith = _.curry((cachizer, initialKeys) => {
   let f = x => {
     let result = x
@@ -53,5 +113,18 @@ export let uniqueStringWith = _.curry((cachizer, initialKeys) => {
   return f
 })
 
+
+/**
+ * Returns a function that takes a string and de-duplicates it against an internal cache. Each time this function is called, the resulting deduplicated string is added to the cache. Exposes `cache` and `clear()` properties to read and clear the cache, respectively.
+ * 
+ * @signature array -> string -> string
+ * @example let dedupe = uniqueString()
+ * _.map(dedupe, ['foo', 'foo', 'foo'])  //-> ['foo', 'foo1', 'foo2']
+ * dedupe.cache  //-> { foo: 3, foo1: 1, foo2: 1 }
+ * dedupe.clear()
+ * dedupe.cache  //-> {}
+ * dedupe('foo')  //-> 'foo'
+ * @tags string
+ */
 export let uniqueString = (arr = []) =>
   uniqueStringWith(_.countBy(_.identity), arr)

--- a/src/tree.js
+++ b/src/tree.js
@@ -1,10 +1,36 @@
+/**
+ * All tree functions take a traversal function so that you can customize how to traverse arbitrary nested structures.
+ * 
+ * *Note*: Be careful about cyclic structures that can result in infinite loops, such as objects with references to itself. There are cases where you'd intentionally want to visit the same node multiple times, such as traversing a directed acyclic graph (which would work just fine and eventually terminate, but would visit a node once for each parent it has connected to it) - but it's up to the user to be sure you don't create infinite loops.
+ * @module tree
+ */
+
 import _ from 'lodash/fp'
 import { findIndexed } from './conversion'
 import { push, dotEncoder, slashEncoder } from './array'
 
+/**
+ * A default check if something can be traversed - currently it is arrays and plain objects.
+ * 
+ * @signature node -> bool
+ * @tags tree
+ */
 export let isTraversable = x => _.isArray(x) || _.isPlainObject(x)
+
+/**
+ * The default traversal function used in other tree methods if you don't supply one. It returns false if it's not traversable or empty, and returns the object if it is.
+ * 
+ * @signature node -> [...childNodes]
+ * @tags tree
+ */
 export let traverse = x => isTraversable(x) && !_.isEmpty(x) && x
 
+/**
+ * A depth first search which visits every node returned by `traverse` recursively. Both `pre-order` and `post-order` traversals are supported (and can be mixed freely). `walk` also supports exiting iteration early by returning a truthy value from either the `pre` or `post` functions. The returned value is also the return value of `walk`. The pre, post, and traversal functions are passed the current node as well as the parent stack (where parents[0] is the direct parent).
+ * 
+ * @signature traverse -> (pre, post=_.noop) -> tree -> x
+ * @tags tree
+ */
 export let walk = (next = traverse) => (
   pre,
   post = _.noop,
@@ -33,6 +59,13 @@ export let findIndexedAsync = (f, data, remaining = _.toPairs(data)) => {
   )
 }
 
+
+/**
+ * A version of `walk` which supports async traversals.
+ * 
+ * @signature traverse -> (pre, post=_.noop) -> async tree -> x
+ * @tags tree
+ */
 export let walkAsync = (next = traverse) => (
   pre,
   post = _.noop,
@@ -55,6 +88,12 @@ export let walkAsync = (next = traverse) => (
     )
     .then(stepResult => stepResult || post(tree, index, parents, parentIndexes))
 
+/**
+ * Structure preserving pre-order depth first traversal which clones, mutates, and then returns a tree. Basically `walk` with a `_.cloneDeep` first (similar to a tree map because it preserves structure). `_iteratee` can be any suitable argument to `_.iteratee` https://lodash.com/docs/4.17.5#iteratee
+ * 
+ * @signature traverse -> _iteratee -> tree -> newTree
+ * @tags tree
+ */
 export let transformTree = (next = traverse) =>
   _.curry((f, x) => {
     let result = _.cloneDeep(x)
@@ -62,6 +101,12 @@ export let transformTree = (next = traverse) =>
     return result
   })
 
+/**
+ * Just like `_.reduce`, but traverses over the tree with the traversal function in `pre-order`.
+ * 
+ * @signature traverse -> (accumulator, initialValue, tree) -> x
+ * @tags tree
+ */
 export let reduceTree = (next = traverse) =>
   _.curry((f, result, tree) => {
     walk(next)((...x) => {
@@ -73,6 +118,13 @@ export let reduceTree = (next = traverse) =>
 let writeProperty = (next = traverse) => (node, index, [parent]) => {
   next(parent)[index] = node
 }
+
+/**
+ * Structure preserving tree map! `writeNode` informs how to write a single node, but the default will generally work for most cases. The iteratee is passed the standard `node, index, parents, parentIndexes` args and is expected to return a transformed node.
+ * 
+ * @signature (traverse, writeNode) -> f -> tree -> newTree
+ * @tags tree
+ */
 export let mapTree = (next = traverse, writeNode = writeProperty(next)) =>
   _.curry(
     (mapper, tree) =>
@@ -81,6 +133,13 @@ export let mapTree = (next = traverse, writeNode = writeProperty(next)) =>
           writeNode(mapper(node, i, parents, ...args), i, parents, ...args)
       })(mapper(tree)) // run mapper on root, and skip root in traversal
   )
+
+/**
+ * Like `mapTree`, but only operates on lead nodes. It is a convenience method for `mapTree(next, writeNode)(F.unless(next, mapper), tree)`
+ * 
+ * @signature (traverse, writeNode) -> f -> tree -> newTree
+ * @tags tree
+ */
 export let mapTreeLeaves = (next = traverse, writeNode = writeProperty(next)) =>
   _.curry((mapper, tree) =>
     // this unless wrapping can be done in user land, this is pure convenience
@@ -88,14 +147,35 @@ export let mapTreeLeaves = (next = traverse, writeNode = writeProperty(next)) =>
     mapTree(next, writeNode)(node => (next(node) ? node : mapper(node)), tree)
   )
 
+
+/**
+ * Like `treeToArray`, but accepts a customizer to process the tree nodes before putting them in an array. The customizer is passed the standard `node, index, parents, parentIndexes` args and is expected to return a transformed node. It's `_.map` for trees - but it's not called treeMap because it does not preserve the structure as you might expect `map` to do. See `mapTree` for that behavior.
+ * 
+ * @signature traverse -> f -> tree -> [f(treeNode), f(treeNode), ...]
+ * @tags tree
+ */
 export let treeToArrayBy = (next = traverse) =>
   _.curry((fn, tree) =>
     reduceTree(next)((r, ...args) => push(fn(...args), r), [], tree)
   )
+
+/**
+ * Flattens the tree nodes into an array, simply recording the node values in pre-order traversal.
+ * 
+ * @signature traverse -> tree -> [treeNode, treeNode, ...]
+ * @tags tree
+ */
 export let treeToArray = (next = traverse) => treeToArrayBy(next)(x => x)
 
 // This could reuse treeToArrayBy and just reject traversable elements after, but this is more efficient
 // We can potentially unify these with tree transducers
+
+/**
+ * Like `leaves`, but accepts a customizer to process the leaves before putting them in an array.
+ * 
+ * @signature traverse -> f -> tree -> [f(treeNode), f(treeNode), ...]
+ * @tags tree
+ */
 export let leavesBy = (next = traverse) =>
   _.curry((fn, tree) =>
     reduceTree(next)(
@@ -104,8 +184,22 @@ export let leavesBy = (next = traverse) =>
       tree
     )
   )
+
+/**
+ * Returns an array of the tree nodes that can't be traversed into in `pre-order`.
+ * 
+ * @signature traverse -> tree -> [treeNodes]
+ * @tags tree
+ */
 export let leaves = (next = traverse) => leavesBy(next)(x => x)
 
+
+/**
+ * Looks up a node matching a path, which defaults to lodash `iteratee` but can be customized with buildIteratee. The `_iteratee` members of the array can be any suitable arguments for `_.iteratee` https://lodash.com/docs/4.17.5#iteratee
+ * 
+ * @signature (traverse, buildIteratee) -> ([_iteratee], tree) -> treeNode
+ * @tags tree
+ */
 export let treeLookup = (next = traverse, buildIteratee = _.identity) =>
   _.curry((path, tree) =>
     _.reduce(
@@ -115,6 +209,12 @@ export let treeLookup = (next = traverse, buildIteratee = _.identity) =>
     )
   )
 
+/**
+ * Similar to a keyBy (aka groupBy) for trees, but also transforms the grouped values (instead of filtering out tree nodes). The transformer takes three args, the current node, a boolean of if the node matches the current group, and what group is being evaluated for this iteratee. The transformer is called on each node for each grouping. `_iteratee` is any suitable argument to `_.iteratee`, as above.
+ * 
+ * @signature traverse -> transformer -> _iteratee -> tree -> result
+ * @tags tree
+ */
 export let keyTreeByWith = (next = traverse) =>
   _.curry((transformer, groupIteratee, x) =>
     _.flow(
@@ -131,13 +231,48 @@ export let keyTreeByWith = (next = traverse) =>
   )
 
 // Flat Tree
+
+/**
+ * A utility tree iteratee that returns the stack of node indexes
+ * 
+ * @signature (x, i, xs, is) => [i, ...is]
+ * @tags tree
+ */
 export let treeKeys = (x, i, xs, is) => [i, ...is]
+
+/**
+ * A utility tree iteratee that returns the stack of node values
+ * 
+ * @signature (x, i, xs) => [x, ...xs]
+ * @tags tree
+ */
 export let treeValues = (x, i, xs) => [x, ...xs]
+
+/**
+ * Creates a path builder for use in `flattenTree`. By default, the builder will look use child indexes and a dotEncoder. Encoder can be an encoding function or a futil `encoder` (an object with encode and decode functions)
+ * 
+ * @signature (build, encoder) -> treePathBuilderFunction
+ * @tags tree
+ */
 export let treePath = (build = treeKeys, encoder = dotEncoder) => (...args) =>
   (encoder.encode || encoder)(build(...args).reverse())
+
+/**
+ * Creates a path builder for use in `flattenTree`, using a slashEncoder and using the specified prop function as an iteratee on each node to determine the keys.
+ * 
+ * @signature prop -> treePathBuilderFunction
+ * @tags tree
+ */
 export let propTreePath = prop =>
   treePath(_.flow(treeValues, _.map(prop)), slashEncoder)
 
+
+/**
+ * Creates a flat object with a property for each node, using `buildPath` to determine the keys. `buildPath` takes the same arguments as a tree walking iteratee. It will default to a dot tree path.
+ * 
+ * @signature traverse -> buildPath -> tree -> result
+ * @tags tree
+ */
 export let flattenTree = (next = traverse) => (buildPath = treePath()) =>
   reduceTree(next)(
     (result, node, ...x) => _.set([buildPath(node, ...x)], node, result),
@@ -146,6 +281,14 @@ export let flattenTree = (next = traverse) => (buildPath = treePath()) =>
 
 export let flatLeaves = (next = traverse) => _.reject(next)
 
+
+/**
+ * Takes a traversal function and returns an object with all of the tree methods pre-applied with the traversal. This is useful if you want to use a few of the tree methods with a custom traversal and can provides a slightly nicer api.
+Exposes provided `traverse` function as `traverse`
+ * 
+ * @signature (traverse, buildIteratee, writeNode) -> {walk, reduce, transform, toArray, toArrayBy, leaves, leavesBy, map, mapLeaves, lookup, keyByWith, traverse, flatten, flatLeaves }
+ * @tags tree
+ */
 export let tree = (
   next = traverse,
   buildIteratee = _.identity,


### PR DESCRIPTION
This is another prep PR for the new docs site - the readme and docs site will be generated from JSON which is generated from inlined jsdoc comments.

The next PR will rearrange the source and/or readme to get them aligned in the same order