### PR TITLE
minor standardization effort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 1.71.2
+- Tests: 
+  - Replaces `eql` for `deep.equal`
+  - Removed all unnecessary `deep.equal` assertions
+  - Replaced `to.equal(true)` and `to.equal(false)` with `to.be.true` and `to.be.false`
+
 # 1.71.1
 - Organized and added to regexp tests
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # 1.71.2
 - Tests: 
-  - Replaces `eql` for `deep.equal`
-  - Removed all unnecessary `deep.equal` assertions
+  - Replaced all `eql` with `deep.equal`
+  - Replaced all unnecessary `deep.equal` assertions with `.equal`
   - Replaced `to.equal(true)` and `to.equal(false)` with `to.be.true` and `to.be.false`
 
 # 1.71.1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "futil-js",
-  "version": "1.71.1",
+  "version": "1.71.2",
   "description": "F(unctional) util(ities). Resistance is futile.",
   "main": "lib/futil-js.js",
   "scripts": {

--- a/test/array.spec.js
+++ b/test/array.spec.js
@@ -5,18 +5,18 @@ const expect = chai.expect
 
 describe('Array Functions', () => {
   it('compactJoin', () => {
-    expect(F.compactJoin(',', [1, undefined, 2, null, 3])).to.eql('1,2,3')
-    expect(F.compactJoin(' and ', [null, 'Alice', 'Bob', false])).to.eql(
+    expect(F.compactJoin(',', [1, undefined, 2, null, 3])).to.equal('1,2,3')
+    expect(F.compactJoin(' and ', [null, 'Alice', 'Bob', false])).to.equal(
       'Alice and Bob'
     )
   })
   it('dotJoin', () => {
-    expect(F.dotJoin([1, undefined, 2, null, 3])).to.eql('1.2.3')
-    expect(F.dotJoin([null, 'Alice', 'Bob', false])).to.eql('Alice.Bob')
+    expect(F.dotJoin([1, undefined, 2, null, 3])).to.equal('1.2.3')
+    expect(F.dotJoin([null, 'Alice', 'Bob', false])).to.equal('Alice.Bob')
   })
   it('repeated', () => {
-    expect(F.repeated([1, 1, 2, 3, 3, 4])).to.eql([1, 3])
-    expect(F.repeated(['a', 'b', 'b'])).to.eql(['b'])
+    expect(F.repeated([1, 1, 2, 3, 3, 4])).to.deep.equal([1, 3])
+    expect(F.repeated(['a', 'b', 'b'])).to.deep.equal(['b'])
   })
   it('push', () => {
     let arr = [1, 2, 3]
@@ -65,11 +65,11 @@ describe('Array Functions', () => {
     expect(cycle(4)).to.equal(1)
 
     cycle = F.cycle([true, false])
-    expect(cycle(true)).to.equal(false)
-    expect(cycle(false)).to.equal(true)
-    expect(cycle(null)).to.equal(true)
+    expect(cycle(true)).to.be.false
+    expect(cycle(false)).to.be.true
+    expect(cycle(null)).to.be.true
 
-    expect(F.cycle([true, false], true)).to.equal(false)
+    expect(F.cycle([true, false], true)).to.be.false
   })
   it('arrayToObject', () => {
     expect(
@@ -107,15 +107,15 @@ describe('Array Functions', () => {
   })
   it('encoder', () => {
     let encoder = F.encoder('->')
-    expect(encoder.encode(['a', 'b'])).to.deep.equal('a->b')
+    expect(encoder.encode(['a', 'b'])).to.equal('a->b')
     expect(encoder.decode('a->b')).to.deep.equal(['a', 'b'])
   })
   it('dotEncoder', () => {
-    expect(F.dotEncoder.encode(['a', 'b'])).to.deep.equal('a.b')
+    expect(F.dotEncoder.encode(['a', 'b'])).to.equal('a.b')
     expect(F.dotEncoder.decode('a.b')).to.deep.equal(['a', 'b'])
   })
   it('slashEncoder', () => {
-    expect(F.slashEncoder.encode(['a', 'b'])).to.deep.equal('a/b')
+    expect(F.slashEncoder.encode(['a', 'b'])).to.equal('a/b')
     expect(F.slashEncoder.decode('a/b')).to.deep.equal(['a', 'b'])
   })
   it('chunkBy', () => {

--- a/test/aspect.spec.js
+++ b/test/aspect.spec.js
@@ -20,9 +20,9 @@ describe('Aspect Functions', () => {
   it('should combine aspect states', async () => {
     let f = Command(() => 6)
     expect(f.state.status).to.equal(null)
-    expect(f.state.processing).to.equal(false)
-    expect(f.state.failed).to.equal(false)
-    expect(f.state.succeeded).to.equal(false)
+    expect(f.state.processing).to.be.false
+    expect(f.state.failed).to.be.false
+    expect(f.state.succeeded).to.be.false
     expect(f.state.logs).to.deep.equal([])
     expect(f.state.errors).to.deep.equal([])
   })
@@ -37,10 +37,10 @@ describe('Aspect Functions', () => {
     let g = Command(() => {
       throw Error(5)
     })
-    expect(g.state.processing).to.equal(false)
+    expect(g.state.processing).to.be.false
     await g()
     expect(g.state.errors[0].message).to.equal('5')
-    expect(g.state.processing).to.equal(false)
+    expect(g.state.processing).to.be.false
     // Should be blocked as a concurrent run since it's still processing
     g.state.processing = true
     await g()
@@ -66,7 +66,7 @@ describe('Aspect Functions', () => {
       throw Error('Hi')
     })
     await throwsHi()
-    expect(throwsHi.state.error.message).to.deep.equal('Hi')
+    expect(throwsHi.state.error.message).to.equal('Hi')
   })
   it('should support status and clearing status', async () => {
     // Increase the timeout/delay to hundreds ms to make testing IE9/10/11 more
@@ -77,10 +77,10 @@ describe('Aspect Functions', () => {
     let result = f()
     await Promise.delay(100)
     expect(f.state.status).to.equal('processing')
-    expect(f.state.processing).to.equal(true)
+    expect(f.state.processing).to.be.true
     await result
     expect(f.state.status).to.equal('succeeded')
-    expect(f.state.succeeded).to.equal(true)
+    expect(f.state.succeeded).to.be.true
     await Promise.delay(300)
     expect(f.state.status).to.equal(null)
     let g = clearingStatus(async () => {
@@ -88,7 +88,7 @@ describe('Aspect Functions', () => {
     })
     await g()
     expect(g.state.status).to.equal('failed')
-    expect(g.state.failed).to.equal(true)
+    expect(g.state.failed).to.be.true
     await Promise.delay(15)
     expect(f.state.status).to.equal(null)
   })
@@ -113,6 +113,6 @@ describe('Aspect Functions', () => {
   it('should mark deprecated methods on state', () => {
     let fn = aspects.deprecate('test', '1.2.3', 'something else')(() => {})
 
-    expect(fn.state.isDeprecated).to.equal(true)
+    expect(fn.state.isDeprecated).to.be.true
   })
 })

--- a/test/collections.spec.js
+++ b/test/collections.spec.js
@@ -12,7 +12,7 @@ describe('Collections Functions', () => {
         (n) => n + n,
         (n) => n * n
       )([0, 1, 2, 3, 4])
-    ).to.eql([0, 4, 16, 36, 64])
+    ).to.deep.equal([0, 4, 16, 36, 64])
     expect(
       F.flowMap(
         (s) => s.toUpperCase(),
@@ -20,7 +20,7 @@ describe('Collections Functions', () => {
         (s) => s.reverse(),
         (s) => s.join('')
       )(['Smart', 'Procure'])
-    ).to.eql(['TRAMS', 'ERUCORP'])
+    ).to.deep.equal(['TRAMS', 'ERUCORP'])
   })
   it('findApply', () => {
     let x = {
@@ -49,9 +49,9 @@ describe('Collections Functions', () => {
       const arr = [0, [1, [2, []]]]
       const arrBackup = _.cloneDeep(arr)
       const arrMutated = F.deepMap((e) => e.concat(101), arr)
-      //      Checking immutability
-      expect(arr).to.eql(arrBackup)
-      expect(arrMutated).to.eql([0, [1, [2, [101], 101], 101]])
+      // Checking immutability
+      expect(arr).to.deep.equal(arrBackup)
+      expect(arrMutated).to.deep.equal([0, [1, [2, [101], 101], 101]])
     })
     it('deepMap plain objects', () => {
       const objA = {
@@ -76,8 +76,8 @@ describe('Collections Functions', () => {
       const setMatchedA = (e) => e.match && _.set(pathA, true, e)
       const objAMutated = F.deepMap((e) => setMatchedA(e) || e)(objA)
       //      Checking immutability
-      expect(objA).to.eql(objABackup)
-      expect(objAMutated).to.eql({
+      expect(objA).to.deep.equal(objABackup)
+      expect(objAMutated).to.deep.equal({
         a: {
           match: {
             id: 1,
@@ -124,9 +124,9 @@ describe('Collections Functions', () => {
       const objBMutated = F.deepMap((e) => push101(e) || setMatchedB(e) || e)(
         objB
       )
-      //         Checking immutability
-      expect(objB).to.eql(objBBackup)
-      expect(objBMutated).to.eql({
+      // Checking immutability
+      expect(objB).to.deep.equal(objBBackup)
+      expect(objBMutated).to.deep.equal({
         a: {
           array: [
             0,
@@ -159,7 +159,7 @@ describe('Collections Functions', () => {
     expect(x).to.deep.equal([1, 5, 2, 3])
     expect(arr).to.deep.equal([1, 2, 3])
 
-    expect(F.insertAtIndex(1, 'z', 'abc')).to.deep.equal('azbc')
+    expect(F.insertAtIndex(1, 'z', 'abc')).to.equal('azbc')
 
     var result = F.insertAtIndex(0, '<span>', 'pretty please')
     expect(result).to.equal('<span>pretty please')

--- a/test/conversions.spec.js
+++ b/test/conversions.spec.js
@@ -12,7 +12,7 @@ describe('Converted Functions', () => {
         father: 'Zeus',
         bornAt: 'Thebes',
       }
-      expect(F.getIn(hero, 'name')).to.eql('Heracles')
+      expect(F.getIn(hero, 'name')).to.equal('Heracles')
       expect(F.getIn(hero, 'Zeus')).to.equal(undefined)
       const obj = { a: 1 }
       expect(F.inversions.getIn(obj)('a')).to.equal(1)
@@ -24,7 +24,7 @@ describe('Converted Functions', () => {
         father: 'Zeus',
         bornAt: 'Thebes',
       }
-      expect(F.getIn(hero, 'name')).to.eql(_.get('name', hero))
+      expect(F.getIn(hero, 'name')).to.equal(_.get('name', hero))
     })
     it('hasIn', () => {
       let hero = {
@@ -32,8 +32,8 @@ describe('Converted Functions', () => {
         father: 'Zeus',
         bornAt: 'Thebes',
       }
-      expect(F.hasIn(hero, 'father')).to.equal(true)
-      expect(F.hasIn(hero, 'Zeus')).to.equal(false)
+      expect(F.hasIn(hero, 'father')).to.be.true
+      expect(F.hasIn(hero, 'Zeus')).to.be.false
     })
     it('pickIn', () => {
       let hero = {
@@ -41,8 +41,8 @@ describe('Converted Functions', () => {
         father: 'Zeus',
         bornAt: 'Thebes',
       }
-      expect(F.pickIn(hero, 'name')).to.eql({ name: 'Heracles' })
-      expect(F.pickIn(hero, ['name', 'father'])).to.eql({
+      expect(F.pickIn(hero, 'name')).to.deep.equal({ name: 'Heracles' })
+      expect(F.pickIn(hero, ['name', 'father'])).to.deep.equal({
         name: 'Heracles',
         father: 'Zeus',
       })
@@ -53,8 +53,8 @@ describe('Converted Functions', () => {
         father: 'Zeus',
         bornAt: 'Thebes',
       }
-      expect(F.pickIn(hero, 'name')).to.eql(_.pick('name', hero))
-      expect(F.pickIn(hero, ['name', 'father'])).to.eql(
+      expect(F.pickIn(hero, 'name')).to.deep.equal(_.pick('name', hero))
+      expect(F.pickIn(hero, ['name', 'father'])).to.deep.equal(
         _.pick(['name', 'father'], hero)
       )
     })
@@ -64,8 +64,8 @@ describe('Converted Functions', () => {
         father: 'Zeus',
         bornAt: 'Thebes',
       }
-      expect(F.includesIn(hero, 'Heracles')).to.eql(true)
-      expect(F.includesIn(hero, 'name')).to.eql(false)
+      expect(F.includesIn(hero, 'Heracles')).to.be.true
+      expect(F.includesIn(hero, 'name')).to.be.false
     })
     it('includesIn consistent with _.includes', () => {
       let hero = {
@@ -73,11 +73,11 @@ describe('Converted Functions', () => {
         father: 'Zeus',
         bornAt: 'Thebes',
       }
-      let expectEql = (obj, name) =>
-        expect(F.includesIn(obj, name)).to.eql(_.includes(name, obj))
-      expectEql(hero, 'name')
-      expectEql(hero, 'Heracles')
-      expectEql(hero, 'Zeus')
+      let expectDeepEqual = (obj, name) =>
+        expect(F.includesIn(obj, name)).to.deep.equal(_.includes(name, obj))
+      expectDeepEqual(hero, 'name')
+      expectDeepEqual(hero, 'Heracles')
+      expectDeepEqual(hero, 'Zeus')
     })
   })
 
@@ -106,10 +106,10 @@ describe('Converted Functions', () => {
         father: 'Zeus',
         bornAt: 'Thebes',
       }
-      let expectEql = (clone, obj) =>
-        expect(F.extendOn(clone, obj)).to.eql(_.extend(obj, clone))
-      expectEql(_.clone(hero), { name: 'Hercules' })
-      expectEql(_.clone(hero), { consort: 'Auge' })
+      let expectDeepEqual = (clone, obj) =>
+        expect(F.extendOn(clone, obj)).to.deep.equal(_.extend(obj, clone))
+      expectDeepEqual(_.clone(hero), { name: 'Hercules' })
+      expectDeepEqual(_.clone(hero), { consort: 'Auge' })
     })
     it('defaultsOn', () => {
       expect(
@@ -136,7 +136,7 @@ describe('Converted Functions', () => {
         bornAt: 'Thebes',
       }
       let clone = _.clone(hero)
-      expect(F.defaultsOn(clone, { consort: 'Auge' })).to.eql(
+      expect(F.defaultsOn(clone, { consort: 'Auge' })).to.deep.equal(
         _.defaults({ consort: 'Auge' }, clone)
       )
     })
@@ -162,7 +162,7 @@ describe('Converted Functions', () => {
     })
     it('unsetOn', () => {
       let object = { a: [{ b: { c: 3 } }] }
-      expect(F.unsetOn('a[0].b.c')(object)).to.deep.equal(true)
+      expect(F.unsetOn('a[0].b.c')(object)).to.be.true
       expect(object).to.deep.equal({ a: [{ b: {} }] })
     })
     it('pullOn', () => {

--- a/test/function.spec.js
+++ b/test/function.spec.js
@@ -8,21 +8,21 @@ chai.use(sinonChai)
 
 describe('Function Functions', () => {
   it('maybeCall', () => {
-    expect(F.maybeCall(() => 5)).to.deep.equal(5)
-    expect(F.maybeCall(null)).to.deep.equal(false)
+    expect(F.maybeCall(() => 5)).to.equal(5)
+    expect(F.maybeCall(null)).to.be.false
     const fn = (x, y) => x + y
-    expect(F.maybeCall(fn, 5, 6)).to.deep.equal(11)
+    expect(F.maybeCall(fn, 5, 6)).to.equal(11)
     // maybeCall should call fn with parameters
-    expect(F.maybeCall(fn, 5, 6)).to.deep.equal(fn(5, 6))
+    expect(F.maybeCall(fn, 5, 6)).to.equal(fn(5, 6))
   })
   it('callOrReturn', () => {
-    expect(F.callOrReturn(() => 5)).to.deep.equal(5)
-    expect(F.callOrReturn(5)).to.deep.equal(5)
-    expect(F.callOrReturn(null)).to.deep.equal(null)
+    expect(F.callOrReturn(() => 5)).to.equal(5)
+    expect(F.callOrReturn(5)).to.equal(5)
+    expect(F.callOrReturn(null)).to.equal(null)
     const fn = (x, y) => x + y
-    expect(F.callOrReturn(fn, 5, 6)).to.deep.equal(11)
+    expect(F.callOrReturn(fn, 5, 6)).to.equal(11)
     // callOrReturn should call fn with parameters
-    expect(F.callOrReturn(fn, 5, 6)).to.deep.equal(fn(5, 6))
+    expect(F.callOrReturn(fn, 5, 6)).to.equal(fn(5, 6))
   })
   it('boundMethod', () => {
     // boundMethod should bind a method of an object to it's object
@@ -42,12 +42,12 @@ describe('Function Functions', () => {
     let sum = (arr) => _.sum(arr)
     let length = (arr) => arr.length
     // average
-    expect(F.converge(divide, [sum, length])([5, 10, 15])).to.deep.equal(10)
+    expect(F.converge(divide, [sum, length])([5, 10, 15])).to.equal(10)
   })
   it('composeApply', () => {
     let fn1 = (lastResult) => (x) => lastResult / x
     let fn2 = (x) => x + 5
-    expect(F.composeApply(fn1, fn2)(5)).to.deep.equal(2)
+    expect(F.composeApply(fn1, fn2)(5)).to.equal(2)
   })
   it('comply', () => {
     // F.append(x => x * 2)(5) => (5 * 2) + 5

--- a/test/iterators.spec.js
+++ b/test/iterators.spec.js
@@ -11,6 +11,6 @@ describe('Iterator Generators', () => {
         { a: 1, b: 2 },
         { a: 1, b: 2 },
       ])
-    ).to.eql([1, 1, 2])
+    ).to.deep.equal([1, 1, 2])
   })
 })

--- a/test/lang.spec.js
+++ b/test/lang.spec.js
@@ -15,77 +15,77 @@ describe('Lang Functions', () => {
     try {
       F.tapError(errorFn)(errorOfMine, 20, 45)
     } catch (e) {
-      expect(total).to.deep.equal('Error: myError. The total is 65')
-      expect(e).to.deep.equal(errorOfMine)
+      expect(total).to.equal('Error: myError. The total is 65')
+      expect(e).to.equal(errorOfMine)
     }
   })
   it('isNotNil', () => {
-    expect(F.isNotNil(null)).to.equal(false)
-    expect(F.isNotNil(undefined)).to.equal(false)
-    expect(F.isNotNil(0)).to.equal(true)
-    expect(F.isNotNil('')).to.equal(true)
-    expect(F.isNotNil([])).to.equal(true)
+    expect(F.isNotNil(null)).to.be.false
+    expect(F.isNotNil(undefined)).to.be.false
+    expect(F.isNotNil(0)).to.be.true
+    expect(F.isNotNil('')).to.be.true
+    expect(F.isNotNil([])).to.be.true
     expect(F.isNotNil).to.equal(F.exists)
   })
   it('exists', () => {
-    expect(F.exists(null)).to.equal(false)
-    expect(F.exists(undefined)).to.equal(false)
-    expect(F.exists(0)).to.equal(true)
-    expect(F.exists('')).to.equal(true)
-    expect(F.exists([])).to.equal(true)
+    expect(F.exists(null)).to.be.false
+    expect(F.exists(undefined)).to.be.false
+    expect(F.exists(0)).to.be.true
+    expect(F.exists('')).to.be.true
+    expect(F.exists([])).to.be.true
   })
   it('isMultiple', () => {
-    expect(F.isMultiple([''])).to.equal(false)
-    expect(F.isMultiple(['', ''])).to.equal(true)
-    expect(F.isMultiple('a')).to.equal(false)
-    expect(F.isMultiple('asdf')).to.equal(true)
-    expect(F.isMultiple({ x: 1, y: 2 })).to.equal(false)
-    expect(F.isMultiple({ x: 1, y: 2, length: 2 })).to.equal(true)
+    expect(F.isMultiple([''])).to.be.false
+    expect(F.isMultiple(['', ''])).to.be.true
+    expect(F.isMultiple('a')).to.be.false
+    expect(F.isMultiple('asdf')).to.be.true
+    expect(F.isMultiple({ x: 1, y: 2 })).to.be.false
+    expect(F.isMultiple({ x: 1, y: 2, length: 2 })).to.be.true
   })
   it('append', () => {
     expect(F.append('a', 'b')).to.equal('ba')
     expect(F.append(1, 4)).to.equal(5)
   })
   it('isBlank', () => {
-    expect(F.isBlank(1)).to.equal(false)
-    expect(F.isBlank('asdf')).to.equal(false)
-    expect(F.isBlank({ a: 1 })).to.equal(false)
-    expect(F.isBlank([3, 4])).to.equal(false)
-    expect(F.isBlank(new Date())).to.equal(false)
+    expect(F.isBlank(1)).to.be.false
+    expect(F.isBlank('asdf')).to.be.false
+    expect(F.isBlank({ a: 1 })).to.be.false
+    expect(F.isBlank([3, 4])).to.be.false
+    expect(F.isBlank(new Date())).to.be.false
     expect(
       F.isBlank({
         a: 1,
         b: 'as',
       })
-    ).to.equal(false)
-    expect(F.isBlank(null)).to.equal(true)
-    expect(F.isBlank(undefined)).to.equal(true)
-    expect(F.isBlank('')).to.equal(true)
-    expect(F.isBlank([])).to.equal(true)
-    expect(F.isBlank({})).to.equal(true)
+    ).to.be.false
+    expect(F.isBlank(null)).to.be.true
+    expect(F.isBlank(undefined)).to.be.true
+    expect(F.isBlank('')).to.be.true
+    expect(F.isBlank([])).to.be.true
+    expect(F.isBlank({})).to.be.true
   })
   it('isNotBlank', () => {
-    expect(F.isNotBlank(1)).to.equal(true)
-    expect(F.isNotBlank('asdf')).to.equal(true)
-    expect(F.isNotBlank({ a: 1 })).to.equal(true)
-    expect(F.isNotBlank([3, 4])).to.equal(true)
-    expect(F.isNotBlank(new Date())).to.equal(true)
-    expect(F.isNotBlank(null)).to.equal(false)
-    expect(F.isNotBlank(undefined)).to.equal(false)
-    expect(F.isNotBlank('')).to.equal(false)
-    expect(F.isNotBlank([])).to.equal(false)
-    expect(F.isNotBlank({})).to.equal(false)
+    expect(F.isNotBlank(1)).to.be.true
+    expect(F.isNotBlank('asdf')).to.be.true
+    expect(F.isNotBlank({ a: 1 })).to.be.true
+    expect(F.isNotBlank([3, 4])).to.be.true
+    expect(F.isNotBlank(new Date())).to.be.true
+    expect(F.isNotBlank(null)).to.be.false
+    expect(F.isNotBlank(undefined)).to.be.false
+    expect(F.isNotBlank('')).to.be.false
+    expect(F.isNotBlank([])).to.be.false
+    expect(F.isNotBlank({})).to.be.false
   })
   it('isBlankDeep', () => {
-    expect(F.isBlankDeep(_.every)(1)).to.equal(false)
-    expect(F.isBlankDeep(_.every)(false)).to.equal(false)
-    expect(F.isBlankDeep(_.every)('')).to.equal(true)
+    expect(F.isBlankDeep(_.every)(1)).to.be.false
+    expect(F.isBlankDeep(_.every)(false)).to.be.false
+    expect(F.isBlankDeep(_.every)('')).to.be.true
     expect(
       F.isBlankDeep(_.every)({
         a: 1,
         b: 'as',
       })
-    ).to.equal(false)
+    ).to.be.false
     expect(
       F.isBlankDeep(_.every)({
         a: null,
@@ -95,6 +95,6 @@ describe('Lang Functions', () => {
           b: '',
         },
       })
-    ).to.equal(true)
+    ).to.be.true
   })
 })

--- a/test/lens.spec.js
+++ b/test/lens.spec.js
@@ -122,7 +122,7 @@ describe('Lens Functions', () => {
       }
       let l = F.lensOf(object)
       F.flip(l.a)()
-      expect(object.a).to.equal(false)
+      expect(object.a).to.be.false
     })
     it('on', () => {
       let object = {
@@ -130,7 +130,7 @@ describe('Lens Functions', () => {
       }
       let l = F.lensOf(object)
       F.on(l.a)()
-      expect(object.a).to.equal(true)
+      expect(object.a).to.be.true
     })
     it('off', () => {
       let object = {
@@ -138,7 +138,7 @@ describe('Lens Functions', () => {
       }
       let l = F.lensOf(object)
       F.off(l.a)()
-      expect(object.a).to.equal(false)
+      expect(object.a).to.be.false
     })
   })
   describe('Implicit Lens Prop', () => {
@@ -177,21 +177,21 @@ describe('Lens Functions', () => {
         a: 1,
       }
       F.flip('a', object)()
-      expect(object.a).to.equal(false)
+      expect(object.a).to.be.false
     })
     it('on', () => {
       let object = {
         a: 1,
       }
       F.on('a', object)()
-      expect(object.a).to.equal(true)
+      expect(object.a).to.be.true
     })
     it('off', () => {
       let object = {
         a: 1,
       }
       F.off('a', object)()
-      expect(object.a).to.equal(false)
+      expect(object.a).to.be.false
     })
   })
   describe('additional implicit lens formats', () => {
@@ -252,7 +252,7 @@ describe('Lens Functions', () => {
       }
       // Props for if `x` is in the list
       let props = F.domLens.checkboxValues('x', 'a', state)
-      expect(props.checked).to.equal(true)
+      expect(props.checked).to.be.true
       // uncheck
       props.onChange({ target: { value: false } })
       expect(_.includes('a', state.a)).to.be.false

--- a/test/logic.spec.js
+++ b/test/logic.spec.js
@@ -9,8 +9,8 @@ describe('Logic Functions', () => {
     let ten = (x) => x > 10
     let twenty = (x) => x > 20
     let thirty = (x) => x > 30
-    expect(F.overNone([ten, twenty, thirty])(5)).to.deep.equal(true)
-    expect(F.overNone([ten, twenty, thirty])(15)).to.deep.equal(false)
+    expect(F.overNone([ten, twenty, thirty])(5)).to.be.true
+    expect(F.overNone([ten, twenty, thirty])(15)).to.be.false
   })
   describe('ifElse', () => {
     it('should handle functions', () => {
@@ -86,6 +86,6 @@ describe('Logic Functions', () => {
     let fn = F.whenTruthy(5)
     expect(fn(3)).to.equal(5)
     expect(fn(null)).to.equal(null)
-    expect(fn(false)).to.equal(false)
+    expect(fn(false)).to.be.false
   })
 })

--- a/test/misc.spec.js
+++ b/test/misc.spec.js
@@ -13,11 +13,11 @@ describe('Math Functions', () => {
 
 describe('Promise Functions', () => {
   it('isPromise', () => {
-    expect(F.isPromise(Promise.resolve())).to.equal(true)
-    expect(F.isPromise({ then() {} })).to.equal(true)
-    expect(F.isPromise(null)).to.equal(false)
-    expect(F.isPromise({})).to.equal(false)
-    expect(F.isPromise({ then: true })).to.equal(false)
+    expect(F.isPromise(Promise.resolve())).to.be.true
+    expect(F.isPromise({ then() {} })).to.be.true
+    expect(F.isPromise(null)).to.be.false
+    expect(F.isPromise({})).to.be.false
+    expect(F.isPromise({ then: true })).to.be.false
   })
 })
 

--- a/test/objects.spec.js
+++ b/test/objects.spec.js
@@ -44,14 +44,14 @@ describe('Object Functions', () => {
     })
   })
   it('isEmptyObject', () => {
-    let expectEql = (obj, v) => expect(F.isEmptyObject(obj)).to.equal(v)
-    expectEql({ a: 1 }, false)
-    expectEql({}, true)
+    let expectEqual = (obj, v) => expect(F.isEmptyObject(obj)).to.equal(v)
+    expectEqual({ a: 1 }, false)
+    expectEqual({}, true)
   })
   it('isNotEmptyObject', () => {
-    let expectEql = (obj, v) => expect(F.isNotEmptyObject(obj)).to.equal(v)
-    expectEql({ a: 1 }, true)
-    expectEql({}, false)
+    let expectEqual = (obj, v) => expect(F.isNotEmptyObject(obj)).to.equal(v)
+    expectEqual({ a: 1 }, true)
+    expectEqual({}, false)
   })
   it('stripEmptyObjects', () => {
     expect(
@@ -121,7 +121,7 @@ describe('Object Functions', () => {
       { x: 'b', y: 1 },
       { x: 'a', y: 2 },
       { x: 'c', y: 2 },
-      // { x: 'd', y: 3 },
+      // { x: 'd', y: 3 }, not present
     ])
     // should not unwind strings
     expect(
@@ -193,39 +193,29 @@ describe('Object Functions', () => {
     expect(new1).to.deep.equal({ a: 1 })
   })
   it('matchesSignature', () => {
-    expect(F.matchesSignature([], 0)).to.equal(false)
-    expect(F.matchesSignature([], '')).to.equal(false)
-    expect(F.matchesSignature([], (x) => x)).to.equal(true)
-    expect(F.matchesSignature([], [])).to.equal(true)
-    expect(F.matchesSignature([], { a: 1 })).to.equal(false)
-    expect(F.matchesSignature(['a'], { a: 1 })).to.equal(true)
-    expect(F.matchesSignature(['b'], { a: 1 })).to.equal(false)
-    expect(F.matchesSignature(['a'], { a: 1, b: 2 })).to.equal(false)
-    expect(F.matchesSignature(['a'], { a: undefined, b: undefined })).to.equal(
-      false
-    )
-    expect(F.matchesSignature(['a', 'b'], { a: undefined })).to.equal(true)
+    expect(F.matchesSignature([], 0)).to.be.false
+    expect(F.matchesSignature([], '')).to.be.false
+    expect(F.matchesSignature([], (x) => x)).to.be.true
+    expect(F.matchesSignature([], [])).to.be.true
+    expect(F.matchesSignature([], { a: 1 })).to.be.false
+    expect(F.matchesSignature(['a'], { a: 1 })).to.be.true
+    expect(F.matchesSignature(['b'], { a: 1 })).to.be.false
+    expect(F.matchesSignature(['a'], { a: 1, b: 2 })).to.be.false
+    expect(F.matchesSignature(['a'], { a: undefined, b: undefined })).to.be.false
+    expect(F.matchesSignature(['a', 'b'], { a: undefined })).to.be.true
   })
   it('matchesSome', () => {
-    expect(F.matchesSome({ a: 1, b: 2 })({ a: 1, b: 2, c: 3 })).to.deep.equal(
-      true
-    )
-    expect(F.matchesSome({ a: 1, b: 20 })({ a: 1, b: 2, c: 3 })).to.deep.equal(
-      true
-    )
-    expect(F.matchesSome({ a: 10, b: 2 })({ a: 1, b: 2, c: 3 })).to.deep.equal(
-      true
-    )
-    expect(F.matchesSome({ a: 10, b: 20 })({ a: 1, b: 2, c: 3 })).to.deep.equal(
-      false
-    )
+    expect(F.matchesSome({ a: 1, b: 2 })({ a: 1, b: 2, c: 3 })).to.be.true
+    expect(F.matchesSome({ a: 1, b: 20 })({ a: 1, b: 2, c: 3 })).to.be.true
+    expect(F.matchesSome({ a: 10, b: 2 })({ a: 1, b: 2, c: 3 })).to.be.true
+    expect(F.matchesSome({ a: 10, b: 20 })({ a: 1, b: 2, c: 3 })).to.be.false
   })
   it('compareDeep', () => {
     const o = { a: { b: { c: 1 } } }
-    expect(F.compareDeep('a.b.c', o, 1)).to.deep.equal(true)
-    expect(F.compareDeep('a.b.c', o, 2)).to.deep.equal(false)
-    expect(F.compareDeep('a.b.c')(o, '1')).to.deep.equal(false)
-    expect(F.compareDeep('a.b.c')(o)('1')).to.deep.equal(false)
+    expect(F.compareDeep('a.b.c', o, 1)).to.be.true
+    expect(F.compareDeep('a.b.c', o, 2)).to.be.false
+    expect(F.compareDeep('a.b.c')(o, '1')).to.be.false
+    expect(F.compareDeep('a.b.c')(o)('1')).to.be.false
   })
   // it('mapProp', () => {
   //   const a = F.mapProp('a', val => val * val, { a: 2, b: 1 })
@@ -235,30 +225,30 @@ describe('Object Functions', () => {
     expect(F.getOrReturn('x', { a: 1 })).to.deep.equal({ a: 1 })
   })
   it('alias', () => {
-    expect(F.alias('x', { a: 1 })).to.deep.equal('x')
+    expect(F.alias('x', { a: 1 })).to.equal('x')
   })
   it('aliasIn', () => {
-    expect(F.aliasIn({ a: 1 }, 'x')).to.deep.equal('x')
+    expect(F.aliasIn({ a: 1 }, 'x')).to.equal('x')
   })
   it('cascade', () => {
-    expect(F.cascade(['x', 'y'], { a: 1, y: 2 })).to.deep.equal(2)
-    expect(F.cascade(['x', 'c'], { a: 1, y: 2 }, 2)).to.deep.equal(2)
-    expect(F.cascade(['x', (x) => x.y], { a: 1, y: 2 })).to.deep.equal(2)
-    expect(F.cascade(['x', 'y'], { a: 1, x: null, y: 2 })).to.deep.equal(2)
+    expect(F.cascade(['x', 'y'], { a: 1, y: 2 })).to.equal(2)
+    expect(F.cascade(['x', 'c'], { a: 1, y: 2 }, 2)).to.equal(2)
+    expect(F.cascade(['x', (x) => x.y], { a: 1, y: 2 })).to.equal(2)
+    expect(F.cascade(['x', 'y'], { a: 1, x: null, y: 2 })).to.equal(2)
   })
   it('cascadeIn', () => {
-    expect(F.cascadeIn({ a: 1, y: 2 }, ['x', 'y'])).to.deep.equal(2)
+    expect(F.cascadeIn({ a: 1, y: 2 }, ['x', 'y'])).to.equal(2)
   })
   it('cascadeKey', () => {
-    expect(F.cascadeKey(['x', 'y'], { a: 1, x: 2 })).to.deep.equal('x')
+    expect(F.cascadeKey(['x', 'y'], { a: 1, x: 2 })).to.equal('x')
   })
   it('cascadePropKey', () => {
-    expect(F.cascadePropKey(['x', 'y'], { a: 1, x: null, y: 2 })).to.deep.equal(
+    expect(F.cascadePropKey(['x', 'y'], { a: 1, x: null, y: 2 })).to.equal(
       'x'
     )
   })
   it('cascadeProp', () => {
-    expect(F.cascadeProp(['x', 'y'], { a: 1, x: null, y: 2 })).to.deep.equal(
+    expect(F.cascadeProp(['x', 'y'], { a: 1, x: null, y: 2 })).to.equal(
       null
     )
   })

--- a/test/objects.spec.js
+++ b/test/objects.spec.js
@@ -201,7 +201,8 @@ describe('Object Functions', () => {
     expect(F.matchesSignature(['a'], { a: 1 })).to.be.true
     expect(F.matchesSignature(['b'], { a: 1 })).to.be.false
     expect(F.matchesSignature(['a'], { a: 1, b: 2 })).to.be.false
-    expect(F.matchesSignature(['a'], { a: undefined, b: undefined })).to.be.false
+    expect(F.matchesSignature(['a'], { a: undefined, b: undefined })).to.be
+      .false
     expect(F.matchesSignature(['a', 'b'], { a: undefined })).to.be.true
   })
   it('matchesSome', () => {
@@ -243,14 +244,10 @@ describe('Object Functions', () => {
     expect(F.cascadeKey(['x', 'y'], { a: 1, x: 2 })).to.equal('x')
   })
   it('cascadePropKey', () => {
-    expect(F.cascadePropKey(['x', 'y'], { a: 1, x: null, y: 2 })).to.equal(
-      'x'
-    )
+    expect(F.cascadePropKey(['x', 'y'], { a: 1, x: null, y: 2 })).to.equal('x')
   })
   it('cascadeProp', () => {
-    expect(F.cascadeProp(['x', 'y'], { a: 1, x: null, y: 2 })).to.equal(
-      null
-    )
+    expect(F.cascadeProp(['x', 'y'], { a: 1, x: null, y: 2 })).to.equal(null)
   })
   it('unkeyBy', () => {
     expect(

--- a/test/regex.spec.js
+++ b/test/regex.spec.js
@@ -5,8 +5,8 @@ const expect = chai.expect
 
 describe('Regexp Functions', () => {
   it('testRegex', () => {
-    expect(F.testRegex(/smart/i)('SmartProcure')).to.equal(true)
-    expect(F.testRegex(/smart/)('SmartProcure')).to.equal(false)
+    expect(F.testRegex(/smart/i)('SmartProcure')).to.be.true
+    expect(F.testRegex(/smart/)('SmartProcure')).to.be.false
   })
 
   it('makeRegExp', () => {
@@ -26,13 +26,13 @@ describe('Regexp Functions', () => {
   })
 
   it('anyWordToRegexp', () => {
-    expect(F.anyWordToRegexp('Any word to regexp')).to.deep.equal(
+    expect(F.anyWordToRegexp('Any word to regexp')).to.equal(
       'Any|word|to|regexp'
     )
   })
 
   it('wordsToRegexp', () => {
-    expect(F.wordsToRegexp('my three words')).to.deep.equal(
+    expect(F.wordsToRegexp('my three words')).to.equal(
       '.*(?=.*my.*)(?=.*three.*)(?=.*words.*).*'
     )
   })
@@ -42,7 +42,7 @@ describe('Regexp Functions', () => {
     const text = 'Here is some to test'
     const match = F.matchAllWords(reText)
 
-    expect(match(text)).to.equal(false)
+    expect(match(text)).to.be.false
   })
 
   it('matchAnyWord', () => {
@@ -50,7 +50,7 @@ describe('Regexp Functions', () => {
     const text = 'Here is some text to test'
     const match = F.matchAnyWord(reText)
 
-    expect(match(text)).to.equal(true)
+    expect(match(text)).to.be.true
   })
 
   it('allMatches', () => {
@@ -127,7 +127,7 @@ describe('Posting Highlight Functions', () => {
       let pattern = 'pr pl'
       let expected =
         '<span class="highlight">pr</span>etty <span class="highlight">pl</span>ease'
-      expect(F.highlight(start, end, pattern, input)).to.deep.equal(expected)
+      expect(F.highlight(start, end, pattern, input)).to.equal(expected)
     })
     it('should highlight from regexp', () => {
       let start = '<span class="highlight">'
@@ -136,7 +136,7 @@ describe('Posting Highlight Functions', () => {
       let pattern = /\bp\w/g
       let expected =
         '<span class="highlight">pr</span>etty <span class="highlight">pl</span>ease nope'
-      expect(F.highlight(start, end, pattern, input)).to.deep.equal(expected)
+      expect(F.highlight(start, end, pattern, input)).to.equal(expected)
     })
   })
 })

--- a/test/tree.spec.js
+++ b/test/tree.spec.js
@@ -156,9 +156,7 @@ describe('Tree Functions', () => {
     }
     let tree = F.tree((x) => x.items)
 
-    expect(tree.lookup([{ a: 2 }, { a: 4 }], x)).to.equal(
-      x.items[0].items[1]
-    )
+    expect(tree.lookup([{ a: 2 }, { a: 4 }], x)).to.equal(x.items[0].items[1])
   })
   it('lookup with path', () => {
     let x = {

--- a/test/tree.spec.js
+++ b/test/tree.spec.js
@@ -8,10 +8,10 @@ const expect = chai.expect
 
 describe('Tree Functions', () => {
   it('isTraversable', () => {
-    expect(F.isTraversable([])).to.equal(true)
-    expect(F.isTraversable({})).to.equal(true)
-    expect(F.isTraversable('')).to.equal(false)
-    expect(F.isTraversable(5)).to.equal(false)
+    expect(F.isTraversable([])).to.be.true
+    expect(F.isTraversable({})).to.be.true
+    expect(F.isTraversable('')).to.be.false
+    expect(F.isTraversable(5)).to.be.false
   })
   it('traverse', () => {
     let x = {
@@ -156,7 +156,7 @@ describe('Tree Functions', () => {
     }
     let tree = F.tree((x) => x.items)
 
-    expect(tree.lookup([{ a: 2 }, { a: 4 }], x)).to.deep.equal(
+    expect(tree.lookup([{ a: 2 }, { a: 4 }], x)).to.equal(
       x.items[0].items[1]
     )
   })
@@ -185,7 +185,7 @@ describe('Tree Functions', () => {
       (x) => x.items,
       (a) => ({ a })
     )
-    expect(tree.lookup(['2', '4'], x)).to.deep.equal(x.items[0].items[1])
+    expect(tree.lookup(['2', '4'], x)).to.equal(x.items[0].items[1])
   })
   it('transform', () => {
     let x = {


### PR DESCRIPTION
- Replaced `eql` for `deep.equal`
- Replaced all unnecessary `deep.equal` assertions with `.equal`
- Replaced `to.equal(true)` and `to.equal(false)` with `to.be.true` and `to.be.false`. Currently, both types can be found across the tests.