### PR TITLE
Test/example fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# 1.71.3
+- Docs site fix. Fixes examples that were being rendered as test instead of examples.
 # 1.71.1
 - Organized and added to regexp tests
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "futil-js",
-  "version": "1.71.1",
+  "version": "1.71.3",
   "description": "F(unctional) util(ities). Resistance is futile.",
   "main": "lib/futil-js.js",
   "scripts": {

--- a/scripts/generate-tests-json.js
+++ b/scripts/generate-tests-json.js
@@ -84,7 +84,7 @@ let run = async () => {
       // Attempt to remove test wrappers but fallback if prettier explodes due to invalid JS
       return format(removeTestWrappers(code))
     } catch (e) {
-      return code
+      return removeTestWrappers(code)
     }
   }, tests)
 


### PR DESCRIPTION
- One-line fix (not even).
- The try-catch is there in case the format() explodes, but even if it does the removeTestWrappers() should still be applied.