### PR TITLE
Bugfix :)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.74.1
+
+- Remove async/await in async `promiseProps` method to avoid downstream regeneratorRuntime issues
+
 # 1.74.0
 
 - Add `flowAsync` and `promiseProps`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "futil-js",
-  "version": "1.74.0",
+  "version": "1.74.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "futil-js",
-  "version": "1.74.0",
+  "version": "1.74.1",
   "description": "F(unctional) util(ities). Resistance is futile.",
   "main": "lib/futil-js.js",
   "scripts": {

--- a/src/async.js
+++ b/src/async.js
@@ -8,7 +8,10 @@ import { resolveOnTree } from './tree'
  */
 export let promiseProps =
   Promise.props ||
-  (async (x) => _.zipObject(_.keys(x), await Promise.all(_.values(x))))
+  ((x) =>
+    Promise.all(_.values(x)).then((values) => _.zipObject(_.keys(x), values)))
+// async/await still causes regeneratorRuntime issues downstream :(
+// (async (x) => _.zipObject(_.keys(x), await Promise.all(_.values(x))))
 
 // Calls then conditionally, allowing flow to be used synchronously, too
 let asyncCall = (value, f) => (value.then ? value.then(f) : f(value))


### PR DESCRIPTION
Remove async/await in async `promiseProps` method to avoid downstream regeneratorRuntime issues.

Moving to modern babel is way overdue :/