### PR TITLE
Fix `intersperse` and `toSentence`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.74.2
+
+- Make `intersperse` handle more edge cases (undefined, null, stirngs, objects, etc)
+- Improve `toSentence` edge cases (mostly from improving intersperse, but also by making strings less surprising)
+
 # 1.74.1
 
 - Remove async/await in async `promiseProps` method to avoid downstream regeneratorRuntime issues

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "futil-js",
-  "version": "1.74.1",
+  "version": "1.74.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "futil-js",
-  "version": "1.74.1",
+  "version": "1.74.2",
   "description": "F(unctional) util(ities). Resistance is futile.",
   "main": "lib/futil-js.js",
   "scripts": {

--- a/src/array.js
+++ b/src/array.js
@@ -233,7 +233,7 @@ export let toggleElement = toggleElementBy(_.includes)
  */
 export let intersperse = _.curry((f, arr) => {
   // Handle nonsense
-  if(_.isEmpty(arr) || _.isString(arr)) return []
+  if (_.isEmpty(arr) || _.isString(arr)) return []
   // Use `_.values` to support objects
   let [x0, ...xs] = _.values(arr)
   return reduceIndexed(

--- a/src/array.js
+++ b/src/array.js
@@ -231,14 +231,18 @@ export let toggleElement = toggleElementBy(_.includes)
  * // **Results:**
  * // **1**, **2** and **3**.
  */
-export let intersperse = _.curry((f, [x0, ...xs]) =>
-  reduceIndexed(
+export let intersperse = _.curry((f, arr) => {
+  // Handle nonsense
+  if(_.isEmpty(arr) || _.isString(arr)) return []
+  // Use `_.values` to support objects
+  let [x0, ...xs] = _.values(arr)
+  return reduceIndexed(
     (acc, x, i) =>
       i === xs.length ? [...acc, x] : [...acc, callOrReturn(f, acc, i, xs), x],
     [x0],
     xs
   )
-)
+})
 
 /**
  * Replaces an element in an array with `value` based on the boolean result of a function `fn`.

--- a/src/string.js
+++ b/src/string.js
@@ -68,6 +68,7 @@ export let autoLabelOptions = _.map(autoLabelOption)
  */
 export let toSentenceWith = _.curry((separator, lastSeparator, array) =>
   _.flow(
+    when(_.isString, x => [x]),
     intersperse(
       differentLast(
         () => separator,

--- a/src/string.js
+++ b/src/string.js
@@ -68,7 +68,7 @@ export let autoLabelOptions = _.map(autoLabelOption)
  */
 export let toSentenceWith = _.curry((separator, lastSeparator, array) =>
   _.flow(
-    when(_.isString, x => [x]),
+    when(_.isString, (x) => [x]),
     intersperse(
       differentLast(
         () => separator,

--- a/test/array.spec.js
+++ b/test/array.spec.js
@@ -166,19 +166,27 @@ describe('Array Functions', () => {
     expect(toggleB(false)).to.deep.equal(['a', 'c'])
   })
   it('intersperse', () => {
+    // Handles iterator functions
     expect(
       F.intersperse(
         (acc, i, xs) => (i === xs.length - 1 ? 'and finally' : 'and'),
         [1, 2, 3, 4]
       )
     ).to.deep.equal([1, 'and', 2, 'and', 3, 'and finally', 4])
-    expect(F.intersperse('and', [1, 2, 3])).to.deep.equal([
-      1,
-      'and',
-      2,
-      'and',
-      3,
-    ])
+
+    // Handles values instead of iterators
+    expect(F.intersperse('&&', [1, 2, 3])).to.deep.equal([1, '&&', 2, '&&', 3])
+    expect(F.intersperse(4, [1, 2, 3])).to.deep.equal([1, 4, 2, 4, 3])
+
+    // Handles nonsense
+    expect(F.intersperse('and', undefined)).to.deep.equal([])
+    expect(F.intersperse('and', true)).to.deep.equal([])
+    expect(F.intersperse('and', 123)).to.deep.equal([])
+    expect(F.intersperse('and', [])).to.deep.equal([])
+    expect(F.intersperse('and', '123')).to.deep.equal([])
+
+    // Treats objects as value arrays
+    expect(F.intersperse('and', { a: 1, b: 2 })).to.deep.equal([1, 'and', 2])
   })
   it('replaceElementBy', () => {
     expect(F.replaceElementBy((c) => c > 10, 0, [1, 11, 3, 5])).to.deep.equal([

--- a/test/string.spec.js
+++ b/test/string.spec.js
@@ -81,9 +81,12 @@ describe('String Functions', () => {
     ).to.equal('first - second or third')
   })
   it('toSentence', () => {
-    expect(F.toSentence(['first', 'second', 'third'])).to.equal(
-      'first, second and third'
-    )
+    expect(F.toSentence(['1st', '2nd', '3rd'])).to.equal('1st, 2nd and 3rd')
+    expect(F.toSentence({ a: '1st', b: '2nd' })).to.equal('1st and 2nd')
+    expect(F.toSentence(undefined)).to.equal('')
+    // Edge cases
+    expect(F.toSentence('1234')).to.equal('1234')
+    expect(F.toSentence(1234)).to.equal('')
   })
   it('uniqueStringWith', () => {
     let a = ['foo20', 'foo21', 'foo23', 'foo24', 'foo25']


### PR DESCRIPTION
Fixes a number of edge cases

- [Make `intersperse` handle more edge cases (undefined, null, stirngs, objects, etc)](https://github.com/smartprocure/futil-js/commit/e8ee29b0f1f57ca8215571b66bd09c9080225583)
- [Improve `toSentence` edge cases (mostly from improving intersperse, but also by making strings less surprising)](https://github.com/smartprocure/futil-js/commit/81da317168c46372a10471b3f492a5369b0fc9cd)