### PR TITLE
More methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Add `renamePropertyOn`, `unsetProperty`
 - Add `updateOwn`, `updateOwnOn`, `updateSome`, `updateSomeOn`, `updateAll`, `updateAllOn`
+- Add `crunchWhitespace`
 
 # 1.74.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 - Pass indexes to `arrayToObject`
 - Add `omitByIndexed` conversion
 - Add `isSubset`
+- Add `sizeBy`
+
 
 # 1.74.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # 1.75.0
 
 - Add `renamePropertyOn`, `popProperty`
-- Add `updateOwn`, `updateOwnOn`, `updateSome`, `updateSomeOn`, `updateAll`, `updateAllOn`
+- Add `updateIfExists`, `updateIfExistsOn`, `updatePaths`, `updatePathsOn`, `updateAllPaths`, `updateAllPathsOn`
 - Add `crunchWhitespace`
 - Export `writeTreeNode`
 - Add `chunkByValue`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Add `chunkByValue`
 - Pass indexes to `arrayToObject`
 - Add `omitByIndexed` conversion
+- Add `isSubset`
 
 # 1.74.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Export `writeTreeNode`
 - Add `chunkByValue`
 - Pass indexes to `arrayToObject`
+- Add `omitByIndexed` conversion
 
 # 1.74.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 1.75.0
 
-- Add `renamePropertyOn`, `unsetProperty`
+- Add `renamePropertyOn`, `popProperty`
 - Add `updateOwn`, `updateOwnOn`, `updateSome`, `updateSomeOn`, `updateAll`, `updateAllOn`
 - Add `crunchWhitespace`
 - Export `writeTreeNode`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.75.0
+
+- Add `renamePropertyOn`, `unsetProperty`
+
 # 1.74.2
 
 - Make `intersperse` handle more edge cases (undefined, null, stirngs, objects, etc)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 1.75.0
 
 - Add `renamePropertyOn`, `unsetProperty`
+- Add `updateOwn`, `updateOwnOn`, `updateSome`, `updateSomeOn`, `updateAll`, `updateAllOn`
 
 # 1.74.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Add `crunchWhitespace`
 - Export `writeTreeNode`
 - Add `chunkByValue`
+- Pass indexes to `arrayToObject`
 
 # 1.74.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - Add `omitByIndexed` conversion
 - Add `isSubset`
 - Add `sizeBy`
-
+- Add `matchesBy`, `matchesBySome`
 
 # 1.74.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Add `updateOwn`, `updateOwnOn`, `updateSome`, `updateSomeOn`, `updateAll`, `updateAllOn`
 - Add `crunchWhitespace`
 - Export `writeTreeNode`
+- Add `chunkByValue`
 
 # 1.74.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Add `renamePropertyOn`, `unsetProperty`
 - Add `updateOwn`, `updateOwnOn`, `updateSome`, `updateSomeOn`, `updateAll`, `updateAllOn`
 - Add `crunchWhitespace`
+- Export `writeTreeNode`
 
 # 1.74.2
 

--- a/README.md
+++ b/README.md
@@ -532,11 +532,11 @@ Example:
 renamePropertyOn('a', 'b', { a: 1 }) -> { b: 1 }
 ```
 
-### unsetProperty
+### popProperty
 
 `k -> { k: v } -> v`
 Removes a property from an object and returns the removed value.
-Like `F.unsetOn`, but returns the removed value instead of the mutated object.
+Like `F.unsetOn`, but returns the removed value instead of the mutated object. Similar to .pop() on arrays, but for objects.
 Supports nested properties using dot notation.
 NOTE: Mutates the object. If you don't want mutation, you probably want `_.unset` for the object or `_.get` for the value.
 
@@ -756,18 +756,18 @@ Takes two objects and returns the keys they have in common
 `(x, y) -> key`
 Takes two objects and returns the first key in `y` that x also has
 
-### updateOwn
+### updateIfExists
 
 `(path, updater, object) -> object`
-Like `_.update`, but does not call the iteratee if the path is missing on the object (so only update "own" properties)
+Like `_.update`, but does not call the iteratee if the path is missing on the object
 
-### updateOwnOn
+### updateIfExistsOn
 
 `(path, updater, object) -> object`
-Like `F.updateOn`, but does not call the iteratee if the path is missing on the object (so only update "own" properties)
+Like `F.updateOn`, but does not call the iteratee if the path is missing on the object
 _Mutates_ the object
 
-### updateSomeOn
+### updatePathsOn
 
 `({ path: transform }, target) -> obj`
 Similar to ramda's `R.evolve`, but supports lodash iteratees and nested paths.
@@ -776,20 +776,9 @@ Transforms are **not** called for paths that do not exist in the target object.
 Transform functions support lodash iteratee shorthand syntax.
 Deep paths are supported by nesting objects and by dotted the keys
 
-Note: _Mutates_ the target object for performance. If you don't want this, use `updateAll` or clone first.
+Note: _Mutates_ the target object for performance. If you don't want this, use `updatePaths` or clone first.
 
-### updateAllOn
-
-`({ path: transform }, target) -> obj`
-Similar to ramda's `R.evolve`, but supports lodash iteratees and nested paths.
-Applies transforms to the target object at each path. The transform function is called with the value at that path, and the result is set at that path.
-Transforms **are** called for paths that do not exist in the target object.
-Transform functions support lodash iteratee shorthand syntax.
-Deep paths are supported by nesting objects and by dotted the keys
-
-Note: _Mutates_ the target object for performance. If you don't want this, use `updateAll` or clone first.
-
-### updateAll
+### updateAllPathsOn
 
 `({ path: transform }, target) -> obj`
 Similar to ramda's `R.evolve`, but supports lodash iteratees and nested paths.
@@ -798,9 +787,20 @@ Transforms **are** called for paths that do not exist in the target object.
 Transform functions support lodash iteratee shorthand syntax.
 Deep paths are supported by nesting objects and by dotted the keys
 
-_Note_ Deep clones prior to executing to avoid mutating the target object, but mutates under the hood for performance (while keeping it immutable at the surface). If you're doing this in a place where mutating is safe, you might want `F.updateAllOn` to avoid the `_.deepClone`
+Note: _Mutates_ the target object for performance. If you don't want this, use `updateAllPaths` or clone first.
 
-### updateSome
+### updateAllPaths
+
+`({ path: transform }, target) -> obj`
+Similar to ramda's `R.evolve`, but supports lodash iteratees and nested paths.
+Applies transforms to the target object at each path. The transform function is called with the value at that path, and the result is set at that path.
+Transforms **are** called for paths that do not exist in the target object.
+Transform functions support lodash iteratee shorthand syntax.
+Deep paths are supported by nesting objects and by dotted the keys
+
+_Note_ Deep clones prior to executing to avoid mutating the target object, but mutates under the hood for performance (while keeping it immutable at the surface). If you're doing this in a place where mutating is safe, you might want `F.updateAllPathsOn` to avoid the `_.deepClone`
+
+### updatePaths
 
 `({ path: transform }, target) -> obj`
 Similar to ramda's `R.evolve`, but supports lodash iteratees and nested paths.
@@ -809,7 +809,7 @@ Transforms are **not** called for paths that do not exist in the target object.
 Transform functions support lodash iteratee shorthand syntax.
 Deep paths are supported by nesting objects and by dotted the keys
 
-_Note_ Deep clones prior to executing to avoid mutating the target object, but mutates under the hood for performance (while keeping it immutable at the surface). If you're doing this in a place where mutating is safe, you might want `F.updateAllOn` to avoid the `_.deepClone`
+_Note_ Deep clones prior to executing to avoid mutating the target object, but mutates under the hood for performance (while keeping it immutable at the surface). If you're doing this in a place where mutating is safe, you might want `F.updatePathsOn` to avoid the `_.deepClone`
 
 ## String
 

--- a/README.md
+++ b/README.md
@@ -201,6 +201,11 @@ Example:
 `(fn, collection) -> collection`
 Maps `fn` over the input collection and compacts the result.
 
+### sizeBy
+
+`(fn, collection) -> number`
+Returns the size of a collection after filtering by `fn`.
+
 ## Convert(\_In)
 
 lodash/fp is great, but sometimes the curry order isn't exactly what you want.
@@ -339,6 +344,11 @@ Example:
 ```jsx
 [[0,7], [3,9], [11,15]] -> [[0,9], [11,15]]
 ```
+
+### isSubset
+
+`([a], [a]) -> boolean`
+Determines if an array is a subset of another array.
 
 ### cycle
 
@@ -810,6 +820,28 @@ Transform functions support lodash iteratee shorthand syntax.
 Deep paths are supported by nesting objects and by dotted the keys
 
 _Note_ Deep clones prior to executing to avoid mutating the target object, but mutates under the hood for performance (while keeping it immutable at the surface). If you're doing this in a place where mutating is safe, you might want `F.updatePathsOn` to avoid the `_.deepClone`
+
+### callOrCompare
+
+Calls a function or defaults to isEqual, used internally by \_matchesBy
+
+### \_matchesBy
+
+Internal function used by `matchesBy` and `matchesBySome`
+
+### matchesBy
+
+`(criteria: object, object: object) -> boolean`
+Takes a criteria object and an object to test against it, and returns true if all the values in the criteria match the values in the object
+Criteria values can be functions or values to compare against
+Supports dot notation for deep paths
+
+### matchesBySome
+
+`(criteria: object, object: object) -> boolean`
+Takes a criteria object and an object to test against it, and returns true if some of the values in the criteria match the values in the object
+Criteria values can be functions or values to compare against
+Supports dot notation for deep paths
 
 ## String
 

--- a/README.md
+++ b/README.md
@@ -821,14 +821,6 @@ Deep paths are supported by nesting objects and by dotted the keys
 
 _Note_ Deep clones prior to executing to avoid mutating the target object, but mutates under the hood for performance (while keeping it immutable at the surface). If you're doing this in a place where mutating is safe, you might want `F.updatePathsOn` to avoid the `_.deepClone`
 
-### callOrCompare
-
-Calls a function or defaults to isEqual, used internally by \_matchesBy
-
-### \_matchesBy
-
-Internal function used by `matchesBy` and `matchesBySome`
-
 ### matchesBy
 
 `(criteria: object, object: object) -> boolean`

--- a/README.md
+++ b/README.md
@@ -289,6 +289,10 @@ Just like `_.reduce`, but with `{cap: false}` so iteratees are not capped (e.g. 
 
 Just like `_.pickBy`, but with `{cap: false}` so iteratees are not capped (e.g. indexes are passed).
 
+### omitByIndexed
+
+Just like `_.omitBy`, but with `{cap: false}` so iteratees are not capped (e.g. indexes are passed).
+
 ### mapValuesIndexed
 
 Just like `_.mapValues`, but with `{cap: false}` so iteratees are not capped (e.g. indexes are passed).
@@ -386,6 +390,11 @@ An encoder using `/` as the separator
 Takes a predicate function and an array, and returns an array of arrays where each element has one or more elements of the original array. Similar to Haskell's [groupBy](http://zvon.org/other/haskell/Outputlist/groupBy_f.html).
 
 The predicate is called with two arguments: the current group, and the current element. If it returns truthy, the element is appended to the current group; otherwise, it's used as the first element in a new group.
+
+### chunkByValue
+
+`f -> [] -> [[], ...]`
+`chunkBy` when the returned value of an iteratee changes
 
 ### toggleElementBy
 
@@ -510,6 +519,26 @@ Example:
 ```jsx
 renameProperty('a', 'b', { a: 1 }) -> { b: 1 }
 ```
+
+### renamePropertyOn
+
+`sourcePropertyName -> targetPropertyName -> sourceObject -> sourceObject`
+Rename a property on an object.
+**NOTE**:Mutates the object
+
+Example:
+
+```jsx
+renamePropertyOn('a', 'b', { a: 1 }) -> { b: 1 }
+```
+
+### unsetProperty
+
+`k -> { k: v } -> v`
+Removes a property from an object and returns the removed value.
+Like `F.unsetOn`, but returns the removed value instead of the mutated object.
+Supports nested properties using dot notation.
+NOTE: Mutates the object. If you don't want mutation, you probably want `_.unset` for the object or `_.get` for the value.
 
 ### unwind
 
@@ -727,6 +756,61 @@ Takes two objects and returns the keys they have in common
 `(x, y) -> key`
 Takes two objects and returns the first key in `y` that x also has
 
+### updateOwn
+
+`(path, updater, object) -> object`
+Like `_.update`, but does not call the iteratee if the path is missing on the object (so only update "own" properties)
+
+### updateOwnOn
+
+`(path, updater, object) -> object`
+Like `F.updateOn`, but does not call the iteratee if the path is missing on the object (so only update "own" properties)
+_Mutates_ the object
+
+### updateSomeOn
+
+`({ path: transform }, target) -> obj`
+Similar to ramda's `R.evolve`, but supports lodash iteratees and nested paths.
+Applies transforms to the target object at each path. The transform function is called with the value at that path, and the result is set at that path.
+Transforms are **not** called for paths that do not exist in the target object.
+Transform functions support lodash iteratee shorthand syntax.
+Deep paths are supported by nesting objects and by dotted the keys
+
+Note: _Mutates_ the target object for performance. If you don't want this, use `updateAll` or clone first.
+
+### updateAllOn
+
+`({ path: transform }, target) -> obj`
+Similar to ramda's `R.evolve`, but supports lodash iteratees and nested paths.
+Applies transforms to the target object at each path. The transform function is called with the value at that path, and the result is set at that path.
+Transforms **are** called for paths that do not exist in the target object.
+Transform functions support lodash iteratee shorthand syntax.
+Deep paths are supported by nesting objects and by dotted the keys
+
+Note: _Mutates_ the target object for performance. If you don't want this, use `updateAll` or clone first.
+
+### updateAll
+
+`({ path: transform }, target) -> obj`
+Similar to ramda's `R.evolve`, but supports lodash iteratees and nested paths.
+Applies transforms to the target object at each path. The transform function is called with the value at that path, and the result is set at that path.
+Transforms **are** called for paths that do not exist in the target object.
+Transform functions support lodash iteratee shorthand syntax.
+Deep paths are supported by nesting objects and by dotted the keys
+
+_Note_ Deep clones prior to executing to avoid mutating the target object, but mutates under the hood for performance (while keeping it immutable at the surface). If you're doing this in a place where mutating is safe, you might want `F.updateAllOn` to avoid the `_.deepClone`
+
+### updateSome
+
+`({ path: transform }, target) -> obj`
+Similar to ramda's `R.evolve`, but supports lodash iteratees and nested paths.
+Applies transforms to the target object at each path. The transform function is called with the value at that path, and the result is set at that path.
+Transforms are **not** called for paths that do not exist in the target object.
+Transform functions support lodash iteratee shorthand syntax.
+Deep paths are supported by nesting objects and by dotted the keys
+
+_Note_ Deep clones prior to executing to avoid mutating the target object, but mutates under the hood for performance (while keeping it immutable at the surface). If you're doing this in a place where mutating is safe, you might want `F.updateAllOn` to avoid the `_.deepClone`
+
 ## String
 
 ### wrap
@@ -813,6 +897,11 @@ dedupe.clear()
 dedupe.cache //-> {}
 dedupe('foo') //-> 'foo'
 ```
+
+### crunchWhitespace
+
+`string -> string`
+Replaces whitespace substrings with a single space and trims leading/trailing whitespace
 
 ## Regex
 
@@ -1206,6 +1295,11 @@ Structure preserving pre-order depth first traversal which clones, mutates, and 
 
 `traverse -> (accumulator, initialValue, tree) -> x`
 Just like `_.reduce`, but traverses over the tree with the traversal function in `pre-order`.
+
+### writeTreeNode
+
+Default `writeNode` for `mapTree`. It writes the node to the parent at the given index.
+Using the traversal function with tree iteratee properties to find children.
 
 ### mapTree
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "futil-js",
-  "version": "1.74.2",
+  "version": "1.75.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "futil-js",
-      "version": "1.72.0",
+      "version": "1.75.0",
       "license": "MIT",
       "dependencies": {
         "babel-polyfill": "^6.23.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "futil-js",
-  "version": "1.74.2",
+  "version": "1.75.0",
   "description": "F(unctional) util(ities). Resistance is futile.",
   "main": "lib/futil-js.js",
   "scripts": {

--- a/scripts/generate-docs.js
+++ b/scripts/generate-docs.js
@@ -24,6 +24,7 @@ let getDocs = async () => {
   let jsDocToJson = _.flow(
     _.reject('undocumented'),
     _.reject({ kind: 'module' }),
+    _.reject({ access: 'private' }),
     _.filter('name'),
     _.map(async (x) => {
       let path = `${x.meta.path}/${x.meta.filename}`

--- a/src/array.js
+++ b/src/array.js
@@ -180,6 +180,19 @@ export let chunkBy = _.curry((f, array) =>
 )
 
 /**
+ * `chunkBy` when the returned value of an iteratee changes
+ *
+ * @signature f -> [] -> [[], ...]
+ * @since 1.75.0
+ */
+export let chunkByValue = _.curry((f, array) =>
+  chunkBy(
+    (group, fn) => _.isEqual(_.iteratee(f)(_.last(group)), _.iteratee(f)(fn)),
+    array
+  )
+)
+
+/**
  * Just like toggleElement, but takes an iteratee to determine if it should remove or add. This is useful for example in situations where you might have a checkbox that you want to represent membership of a value in a set instead of an implicit toggle. Used by includeLens.
  *
  * @signature bool -> value -> list -> newList

--- a/src/array.js
+++ b/src/array.js
@@ -16,6 +16,7 @@ let last = _.takeRight(1)
  * Joins an array after compacting. Note that due to the underlying behavior of `_.curry` no default `join` value is supported -- you must pass in some string with which to perform the join.
  *
  * @signature joinString -> [string1, string2, ...stringN] -> string1 + joinString + string2 + joinString ... + stringN
+ * @typescript {(join: string, x: any[]) => string}
  */
 export let compactJoin = _.curry((join, x) => _.compact(x).join(join))
 
@@ -23,6 +24,7 @@ export let compactJoin = _.curry((join, x) => _.compact(x).join(join))
  * Compacts and joins an array with `.`
  *
  * @signature [string1, string2, ...stringN] -> string1 + '.' + string2 + '.' ... + stringN
+ * @typescript {(arr: any[]) => string}
  */
 export let dotJoin = compactJoin('.')
 
@@ -31,7 +33,7 @@ export let dotJoin = compactJoin('.')
  *
  * @signature filterFunction -> [string1, string2, ...stringN] -> string1 + '.' + string2 + '.' ... + stringN
  */
-export let dotJoinWith = (fn) => (x) => _.filter(fn, x).join('.')
+export let dotJoinWith = (fn) => (x) => _.flow(_.filter(fn), _.join('.'))(x)
 
 /**
  * Returns an array of elements that are repeated in the array.

--- a/src/array.js
+++ b/src/array.js
@@ -1,7 +1,7 @@
 import _ from 'lodash/fp'
 import { callOrReturn } from './function'
 import { insertAtIndex } from './collection'
-import { reduceIndexed } from './conversion'
+import { reduceIndexed, mapIndexed } from './conversion'
 
 // TODO: Move to proper files and expose
 let callUnless = (check) => (failFn) => (fn) => (x, y) =>
@@ -102,13 +102,14 @@ export let cycle = _.curry((a, n) => a[(a.indexOf(n) + 1) % a.length])
  * @signature (k, v, [a]) -> { k(a): v(a) }
  */
 export let arrayToObject = _.curry((k, v, a) =>
-  _.flow(_.keyBy(k), _.mapValues(v))(a)
+  _.zipObject(mapIndexed(k, a), mapIndexed(v, a))
 )
 
 /**
  * Converts and array of keys to an object using a predicate
  *
  * @signature (v, [a]) => { a: v(a) }
+ * @type <T>(fn: (k: string) => T, keys: string[]): { [K in typeof keys[number]]: T } // TS not enforcing the keys :(
  */
 export let keysToObject = arrayToObject((x) => x)
 

--- a/src/array.js
+++ b/src/array.js
@@ -90,6 +90,15 @@ export let mergeRanges = _.flow(
 )
 
 /**
+ * Determines if an array is a subset of another array.
+ * 
+ * @signature ([a], [a]) -> boolean
+ */
+export let isSubset = _.curry(
+  (array1, array2) => _.difference(array1, array2).length === 0
+)
+
+/**
  * Creates a function that takes an element of the original array as argument and returns the next element in the array (with wrapping). Note that (1) This will return the first element of the array for any argument not in the array and (2) due to the behavior of `_.curry` the created function will return a function equivalent to itself if called with no argument.
  *
  * @signature [a, b...] -> a -> b

--- a/src/array.js
+++ b/src/array.js
@@ -109,7 +109,7 @@ export let arrayToObject = _.curry((k, v, a) =>
  * Converts and array of keys to an object using a predicate
  *
  * @signature (v, [a]) => { a: v(a) }
- * @type <T>(fn: (k: string) => T, keys: string[]): { [K in typeof keys[number]]: T } // TS not enforcing the keys :(
+ * @typescript <T>(fn: (k: string) => T, keys: string[]): { [K in typeof keys[number]]: T } // TS not enforcing the keys :(
  */
 export let keysToObject = arrayToObject((x) => x)
 

--- a/src/array.js
+++ b/src/array.js
@@ -93,7 +93,7 @@ export let mergeRanges = _.flow(
 
 /**
  * Determines if an array is a subset of another array.
- * 
+ *
  * @signature ([a], [a]) -> boolean
  */
 export let isSubset = _.curry(

--- a/src/collection.js
+++ b/src/collection.js
@@ -61,3 +61,12 @@ export let insertAtIndex = _.curry((index, val, collection) =>
 export let compactMap = _.curry((fn, collection) =>
   _.flow(_.map(fn), _.compact)(collection)
 )
+
+/**
+ * Returns the size of a collection after filtering by `fn`.
+ *
+ * @signature (fn, collection) -> number
+ */
+export const sizeBy = _.curry((fn, collection) =>
+  _.flow(_.filter(fn), _.size)(collection)
+)

--- a/src/conversion.js
+++ b/src/conversion.js
@@ -170,6 +170,13 @@ export const reduceIndexed = noCap.reduce
 export const pickByIndexed = noCap.pickBy
 
 /**
+ * Just like `_.omitBy`, but with `{cap: false}` so iteratees are not capped (e.g. indexes are passed).
+ *
+ * @tags convert(_Indexed)
+ */
+export const omitByIndexed = noCap.omitBy
+
+/**
  * Just like `_.mapValues`, but with `{cap: false}` so iteratees are not capped (e.g. indexes are passed).
  *
  * @tags convert(_Indexed)

--- a/src/object.js
+++ b/src/object.js
@@ -103,13 +103,13 @@ export const renamePropertyOn = _.curry((from, to, target) => {
 
 /**
  * Removes a property from an object and returns the removed value.
- * Like `F.unsetOn`, but returns the removed value instead of the mutated object.
+ * Like `F.unsetOn`, but returns the removed value instead of the mutated object. Similar to .pop() on arrays, but for objects.
  * Supports nested properties using dot notation.
  * NOTE: Mutates the object. If you don't want mutation, you probably want `_.unset` for the object or `_.get` for the value.
  * @since 1.75.0
  * @signature k -> { k: v } -> v
  */
-export const unsetProperty = _.curry((prop, obj) => {
+export const popProperty = _.curry((prop, obj) => {
   if (_.has(prop, obj)) {
     let value = _.get(prop, obj)
     unsetOn(prop, obj)

--- a/src/object.js
+++ b/src/object.js
@@ -9,6 +9,8 @@ import {
   hasIn,
   mapIndexed,
   mapValuesIndexed,
+  unsetOn,
+  setOn,
 } from './conversion'
 import { findApply } from './collection'
 import { aspects } from './aspect'
@@ -82,6 +84,36 @@ export const renameProperty = _.curry((from, to, target) =>
     ? _.flow((x) => _.set(to, _.get(from, x), x), _.unset(from))(target)
     : target
 )
+
+/**
+ *  Rename a property on an object.
+ *  **NOTE**:Mutates the object
+ *
+ * @since 1.75.0
+ * @signature sourcePropertyName -> targetPropertyName -> sourceObject -> sourceObject
+ * @example renamePropertyOn('a', 'b', { a: 1 }) -> { b: 1 }
+ */
+export const renamePropertyOn = _.curry((from, to, target) => {
+  if (_.has(from, target))
+    _.flow((x) => setOn(to, _.get(from, x), x), unsetOn(from))(target)
+  return target
+})
+
+/**
+ * Removes a property from an object and returns the removed value.
+ * Like `F.unsetOn`, but returns the removed value instead of the mutated object.
+ * Supports nested properties using dot notation.
+ * NOTE: Mutates the object. If you don't want mutation, you probably want `_.unset` for the object or `_.get` for the value.
+ * @since 1.75.0
+ * @signature k -> { k: v } -> v
+ */
+export const unsetProperty = _.curry((prop, obj) => {
+  if (_.has(prop, obj)) {
+    let value = _.get(prop, obj)
+    unsetOn(prop, obj)
+    return value
+  }
+})
 
 /**
  * Just like mongo's `$unwind`: produces an array of objects from an object and one of its array-valued properties. Each object is constructed from the original object with the array value replaced by its elements. Unwinding on a nonexistent property or a property whose value is not an array returns an empty array.

--- a/src/object.js
+++ b/src/object.js
@@ -446,21 +446,21 @@ export let firstCommonKey = _.curry((x, y) =>
 )
 
 /**
- * Like `_.update`, but does not call the iteratee if the path is missing on the object (so only update "own" properties)
+ * Like `_.update`, but does not call the iteratee if the path is missing on the object
  * @signature (path, updater, object) -> object
  * @since 1.75.0
  */
-export let updateOwn = _.curry((path, updater, object) =>
+export let updateIfExists = _.curry((path, updater, object) =>
   _.has(path, object) ? _.update(path, updater, object) : object
 )
 
 /**
- * Like `F.updateOn`, but does not call the iteratee if the path is missing on the object (so only update "own" properties)
+ * Like `F.updateOn`, but does not call the iteratee if the path is missing on the object
  * *Mutates* the object
  * @signature (path, updater, object) -> object
  * @since 1.75.0
  */
-export let updateOwnOn = _.curry((path, updater, object) =>
+export let updateIfExistsOn = _.curry((path, updater, object) =>
   _.has(path, object) ? updateOn(path, updater, object) : object
 )
 
@@ -481,12 +481,12 @@ let _updateMany = _.curry((updater, transforms, data) =>
  * Transform functions support lodash iteratee shorthand syntax.
  * Deep paths are supported by nesting objects and by dotted the keys
  *
- * Note: *Mutates* the target object for performance. If you don't want this, use `updateAll` or clone first.
+ * Note: *Mutates* the target object for performance. If you don't want this, use `updatePaths` or clone first.
  *
  * @signature ({ path: transform }, target) -> obj
  * @since 1.75.0
  */
-export let updateSomeOn = _updateMany(updateOwnOn)
+export let updatePathsOn = _updateMany(updateIfExistsOn)
 
 /**
  * Similar to ramda's `R.evolve`, but supports lodash iteratees and nested paths.
@@ -495,12 +495,12 @@ export let updateSomeOn = _updateMany(updateOwnOn)
  * Transform functions support lodash iteratee shorthand syntax.
  * Deep paths are supported by nesting objects and by dotted the keys
  *
- * Note: *Mutates* the target object for performance. If you don't want this, use `updateAll` or clone first.
+ * Note: *Mutates* the target object for performance. If you don't want this, use `updateAllPaths` or clone first.
  *
  * @signature ({ path: transform }, target) -> obj
  * @since 1.75.0
  */
-export let updateAllOn = _updateMany(updateOn)
+export let updateAllPathsOn = _updateMany(updateOn)
 
 /**
  * Similar to ramda's `R.evolve`, but supports lodash iteratees and nested paths.
@@ -509,13 +509,13 @@ export let updateAllOn = _updateMany(updateOn)
  * Transform functions support lodash iteratee shorthand syntax.
  * Deep paths are supported by nesting objects and by dotted the keys
  *
- * *Note* Deep clones prior to executing to avoid mutating the target object, but mutates under the hood for performance (while keeping it immutable at the surface). If you're doing this in a place where mutating is safe, you might want `F.updateAllOn` to avoid the `_.deepClone`
+ * *Note* Deep clones prior to executing to avoid mutating the target object, but mutates under the hood for performance (while keeping it immutable at the surface). If you're doing this in a place where mutating is safe, you might want `F.updateAllPathsOn` to avoid the `_.deepClone`
  *
  * @signature ({ path: transform }, target) -> obj
  * @since 1.75.0
  */
-export let updateAll = _.curry((transforms, data) =>
-  updateAllOn(transforms, _.cloneDeep(data))
+export let updateAllPaths = _.curry((transforms, data) =>
+  updateAllPathsOn(transforms, _.cloneDeep(data))
 )
 
 /**
@@ -525,11 +525,11 @@ export let updateAll = _.curry((transforms, data) =>
  * Transform functions support lodash iteratee shorthand syntax.
  * Deep paths are supported by nesting objects and by dotted the keys
  *
- * *Note* Deep clones prior to executing to avoid mutating the target object, but mutates under the hood for performance (while keeping it immutable at the surface). If you're doing this in a place where mutating is safe, you might want `F.updateAllOn` to avoid the `_.deepClone`
+ * *Note* Deep clones prior to executing to avoid mutating the target object, but mutates under the hood for performance (while keeping it immutable at the surface). If you're doing this in a place where mutating is safe, you might want `F.updatePathsOn` to avoid the `_.deepClone`
  *
  * @signature ({ path: transform }, target) -> obj
  * @since 1.75.0
  */
-export let updateSome = _.curry((transforms, data) =>
-  updateSomeOn(transforms, _.cloneDeep(data))
+export let updatePaths = _.curry((transforms, data) =>
+  updatePathsOn(transforms, _.cloneDeep(data))
 )

--- a/src/object.js
+++ b/src/object.js
@@ -536,7 +536,7 @@ export let updatePaths = _.curry((transforms, data) =>
 
 /**
  * Calls a function or defaults to isEqual, used internally by _matchesBy
- * 
+ *
  * @private
  * @typescript (fn: (x: any) => any | any, value: any)
  */

--- a/src/object.js
+++ b/src/object.js
@@ -536,6 +536,8 @@ export let updatePaths = _.curry((transforms, data) =>
 
 /**
  * Calls a function or defaults to isEqual, used internally by _matchesBy
+ * 
+ * @private
  * @typescript (fn: (x: any) => any | any, value: any)
  */
 let callOrCompare = (fn, value) =>
@@ -544,6 +546,7 @@ let callOrCompare = (fn, value) =>
 /**
  * Internal function used by `matchesBy` and `matchesBySome`
  *
+ * @private
  * @typescript (combiner: (values: boolean[]) => boolean, criteria: object, object: object)
  */
 let _matchesBy = _.curry((combiner, criteria, object) =>

--- a/src/object.js
+++ b/src/object.js
@@ -558,7 +558,7 @@ let _matchesBy = _.curry((combiner, criteria, object) =>
  * Takes a criteria object and an object to test against it, and returns true if all the values in the criteria match the values in the object
  * Criteria values can be functions or values to compare against
  * Supports dot notation for deep paths
- * 
+ *
  * @signature (criteria: object, object: object) -> boolean
  */
 export let matchesBy = _matchesBy(_.every((x) => x))
@@ -567,7 +567,7 @@ export let matchesBy = _matchesBy(_.every((x) => x))
  * Takes a criteria object and an object to test against it, and returns true if some of the values in the criteria match the values in the object
  * Criteria values can be functions or values to compare against
  * Supports dot notation for deep paths
- * 
+ *
  * @signature (criteria: object, object: object) -> boolean
  */
 export let matchesBySome = _matchesBy(_.some((x) => x))

--- a/src/object.js
+++ b/src/object.js
@@ -533,3 +533,41 @@ export let updateAllPaths = _.curry((transforms, data) =>
 export let updatePaths = _.curry((transforms, data) =>
   updatePathsOn(transforms, _.cloneDeep(data))
 )
+
+/**
+ * Calls a function or defaults to isEqual, used internally by _matchesBy
+ * @typescript (fn: (x: any) => any | any, value: any)
+ */
+let callOrCompare = (fn, value) =>
+  _.isFunction(fn) ? fn(value) : _.isEqual(fn, value)
+
+/**
+ * Internal function used by `matchesBy` and `matchesBySome`
+ *
+ * @typescript (combiner: (values: boolean[]) => boolean, criteria: object, object: object)
+ */
+let _matchesBy = _.curry((combiner, criteria, object) =>
+  _.flow(
+    mapValuesIndexed((value, key) => callOrCompare(value, _.get(key, object))),
+    _.values,
+    combiner
+  )(criteria)
+)
+
+/**
+ * Takes a criteria object and an object to test against it, and returns true if all the values in the criteria match the values in the object
+ * Criteria values can be functions or values to compare against
+ * Supports dot notation for deep paths
+ * 
+ * @signature (criteria: object, object: object) -> boolean
+ */
+export let matchesBy = _matchesBy(_.every((x) => x))
+
+/**
+ * Takes a criteria object and an object to test against it, and returns true if some of the values in the criteria match the values in the object
+ * Criteria values can be functions or values to compare against
+ * Supports dot notation for deep paths
+ * 
+ * @signature (criteria: object, object: object) -> boolean
+ */
+export let matchesBySome = _matchesBy(_.some((x) => x))

--- a/src/object.js
+++ b/src/object.js
@@ -454,7 +454,6 @@ export let updateOwn = _.curry((path, updater, object) =>
   _.has(path, object) ? _.update(path, updater, object) : object
 )
 
-
 /**
  * Like `F.updateOn`, but does not call the iteratee if the path is missing on the object (so only update "own" properties)
  * *Mutates* the object
@@ -464,7 +463,6 @@ export let updateOwn = _.curry((path, updater, object) =>
 export let updateOwnOn = _.curry((path, updater, object) =>
   _.has(path, object) ? updateOn(path, updater, object) : object
 )
-
 
 let _updateMany = _.curry((updater, transforms, data) =>
   _.flow(

--- a/src/string.js
+++ b/src/string.js
@@ -132,3 +132,13 @@ export let uniqueStringWith = _.curry((cachizer, initialKeys) => {
  */
 export let uniqueString = (arr = []) =>
   uniqueStringWith(_.countBy(_.identity), arr)
+
+/**
+ * Replaces whitespace substrings with a single space and trims leading/trailing whitespace
+ * 
+ * @signature string -> string
+ * @type <T>(x: T): string | T
+ * @since 1.75.0
+ */
+export let crunchWhitespace = x =>
+  _.isString(x) ? _.trim(_.replace(/\s+/g, ' ', x)) : x

--- a/src/string.js
+++ b/src/string.js
@@ -135,10 +135,10 @@ export let uniqueString = (arr = []) =>
 
 /**
  * Replaces whitespace substrings with a single space and trims leading/trailing whitespace
- * 
+ *
  * @signature string -> string
- * @type <T>(x: T): string | T
+ * @typescript <T>(x: T): string | T
  * @since 1.75.0
  */
-export let crunchWhitespace = x =>
+export let crunchWhitespace = (x) =>
   _.isString(x) ? _.trim(_.replace(/\s+/g, ' ', x)) : x

--- a/src/tree.js
+++ b/src/tree.js
@@ -109,7 +109,7 @@ export let reduceTree = (next = traverse) =>
 /**
  * Default `writeNode` for `mapTree`. It writes the node to the parent at the given index.
  * Using the traversal function with tree iteratee properties to find children.
- */  
+ */
 export let writeTreeNode =
   (next = traverse) =>
   (node, index, [parent, ...parents], [parentIndex, ...indexes]) => {

--- a/src/tree.js
+++ b/src/tree.js
@@ -106,7 +106,11 @@ export let reduceTree = (next = traverse) =>
     return result
   })
 
-let writeTreeNode =
+/**
+ * Default `writeNode` for `mapTree`. It writes the node to the parent at the given index.
+ * Using the traversal function with tree iteratee properties to find children.
+ */  
+export let writeTreeNode =
   (next = traverse) =>
   (node, index, [parent, ...parents], [parentIndex, ...indexes]) => {
     next(parent, parentIndex, parents, indexes)[index] = node

--- a/test/array.spec.js
+++ b/test/array.spec.js
@@ -61,6 +61,19 @@ describe('Array Functions', () => {
       ])
     ).to.deep.equal([[0, 5]])
   })
+  it('isSubset', () => {
+    // true if first array is a subset of the second
+    expect(F.isSubset([1, 2], [1, 2, 3])).to.equal(true)
+
+    // false if first array is not a subset of the second
+    expect(F.isSubset([1, 2, 4], [1, 2, 3])).to.equal(false)
+
+    // false if first array includes all elements of the second along with others
+    expect(F.isSubset([1, 2, 3, 4], [1, 2, 3])).to.equal(false)
+
+    // true if first string array is a subset of the second
+    expect(F.isSubset(['1', '2'], ['1', '2', '3'])).to.equal(true)
+  })
   it('cycle', () => {
     let cycle = F.cycle([1, 2, 3])
     expect(cycle(1)).to.equal(2)

--- a/test/array.spec.js
+++ b/test/array.spec.js
@@ -83,6 +83,15 @@ describe('Array Functions', () => {
         ['a', 'b', 'c']
       )
     ).to.deep.equal({ keya: 'vala', keyb: 'valb', keyc: 'valc' })
+
+    // Support indexes
+    expect(
+      F.arrayToObject(
+        (x, i) => `key${x}${i}`,
+        (x, i) => `val${x}${i}`,
+        ['a', 'b', 'c']
+      )
+    ).to.deep.equal({ keya0: 'vala0', keyb1: 'valb1', keyc2: 'valc2' })
   })
   it('keysToObject', () => {
     let result = F.keysToObject((v) => Number(v), ['1', '2', '3'])

--- a/test/array.spec.js
+++ b/test/array.spec.js
@@ -142,6 +142,47 @@ describe('Array Functions', () => {
     expect(F.chunkBy(() => false, undefined)).to.deep.equal([])
     expect(F.chunkBy(() => false, [])).to.deep.equal([])
   })
+  it('chunkByValue', () => {
+    // Funciton case
+    expect(
+      F.chunkByValue(
+        (x) => x.str.length,
+        [
+          { a: 1, str: 'asdf' },
+          { a: 2, str: 'qwer' },
+          { b: 1, str: 'b' },
+          { b: 2, str: 'b' },
+        ]
+      )
+    ).to.deep.equal([
+      [
+        { a: 1, str: 'asdf' },
+        { a: 2, str: 'qwer' },
+      ],
+      [
+        { b: 1, str: 'b' },
+        { b: 2, str: 'b' },
+      ],
+    ])
+    // Iteratee support
+    expect(
+      F.chunkByValue('type', [
+        { a: 1, type: 'a' },
+        { a: 1, type: 'a' },
+        { b: 1, type: 'b' },
+        { b: 1, type: 'b' },
+      ])
+    ).to.deep.equal([
+      [
+        { a: 1, type: 'a' },
+        { a: 1, type: 'a' },
+      ],
+      [
+        { b: 1, type: 'b' },
+        { b: 1, type: 'b' },
+      ],
+    ])
+  })
   it('toggleElement', () => {
     expect(F.toggleElement('b', ['a', 'b', 'c', 'd'])).to.deep.equal([
       'a',

--- a/test/collections.spec.js
+++ b/test/collections.spec.js
@@ -182,4 +182,8 @@ describe('Collections Functions', () => {
     ])
     expect(F.compactMap((x) => x - 2, [0, 1, 2, 3])).to.deep.equal([-2, -1, 1])
   })
+  it('sizeBy', () => {
+    let names = ['adam', 'betty', 'carlos', 'doug', 'emily']
+    expect(F.sizeBy((x) => x.length < 5, names)).to.equal(2)
+  })
 })

--- a/test/objects.spec.js
+++ b/test/objects.spec.js
@@ -206,16 +206,16 @@ describe('Object Functions', () => {
     F.renamePropertyOn('d.e', 'd.f', o)
     expect(o).to.deep.equal({ b: 1, d: { f: 2 } })
   })
-  it('unsetProperty', () => {
+  it('popProperty', () => {
     // Basic case
     let basic = { a: 1, b: 2, c: 3 }
-    let a = F.unsetProperty('a', basic)
+    let a = F.popProperty('a', basic)
     expect(a).to.equal(1)
     expect(basic).to.deep.equal({ b: 2, c: 3 })
 
     // Nested case
     let nested = { a: 1, b: 2, c: 3, d: { e: 4, f: 5 } }
-    let e = F.unsetProperty('d.e', nested)
+    let e = F.popProperty('d.e', nested)
     expect(e).to.equal(4)
     expect(nested).to.deep.equal({ a: 1, b: 2, c: 3, d: { f: 5 } })
   })

--- a/test/objects.spec.js
+++ b/test/objects.spec.js
@@ -782,4 +782,152 @@ describe('Object Functions', () => {
 
     expect(F.firstCommonKey(providers, schema)).to.equal('elasticsearch')
   })
+  it('updateOwn', () => {
+    let target = { a: 1, b: 2 }
+    let output = F.updateOwn('a', (x) => x + 1, target)
+    expect(output).to.deep.equal({ a: 2, b: 2 })
+    
+    // Does note mutate
+    expect(output).not.to.deep.equal(target)
+
+    // Does not run for missing keys
+    let missingCase = F.updateOwn('c', (x) => x + 1, { a: 1, b: 2 })
+    expect(missingCase).to.deep.equal({ a: 1, b: 2 })
+  })
+  it('updateOwnOn', () => {
+    let target = { a: 1, b: 2 }
+    let output = F.updateOwnOn('a', (x) => x + 1, target)
+    expect(output).to.deep.equal({ a: 2, b: 2 })
+    
+    // Mutates
+    expect(output).to.deep.equal(target)
+
+    // Does not run for missing keys
+    let missingCase = F.updateOwnOn('c', (x) => x + 1, { a: 1, b: 2 })
+    expect(missingCase).to.deep.equal({ a: 1, b: 2 })
+  })
+  it('updateSome', () => {
+    let transforms = {
+      a: (x) => x + 5,
+      // iteratee support
+      c: 'd',
+      // nested support
+      e: {
+        f: (x) => x * 2,
+      },
+      // nested paths support
+      'e.h': (x) => x + 3,
+      // does not apply transforms if the keys are missing
+      notInObject: () => 'not there',
+    }
+    let input = {
+      a: 1,
+      b: 2,
+      c: { d: 1 },
+      e: { f: 1, g: 2, h: 3 },
+    }
+    let output = F.updateSome(transforms, input)
+    // Handle all cases
+    expect(output).to.deep.equal({ a: 6, b: 2, c: 1, e: { f: 2, g: 2, h: 6 } })
+    // Immutable
+    expect(output).not.to.deep.equal(input)
+    // Handle null transforms
+    expect(F.updateSome(null, { a: 1 })).to.deep.equal({ a: 1 })
+  })
+  it('updateAll', () => {
+    let transforms = {
+      a: (x) => x + 5,
+      // iteratee support
+      c: 'd',
+      // nested support
+      e: {
+        f: (x) => x * 2,
+      },
+      // nested paths support
+      'e.h': (x) => x + 3,
+      // applies transforms even if the keys are missing
+      notInObject: () => 'not there',
+    }
+    let input = {
+      a: 1,
+      b: 2,
+      c: { d: 1 },
+      e: { f: 1, g: 2, h: 3 },
+    }
+    let output = F.updateAll(transforms, input)
+    // Handle all cases
+    expect(output).to.deep.equal({
+      a: 6,
+      b: 2,
+      c: 1,
+      e: { f: 2, g: 2, h: 6 },
+      notInObject: 'not there',
+    })
+    // Immutable
+    expect(output).not.to.deep.equal(input)
+    // Handle null transforms
+    expect(F.updateAll(null, { a: 1 })).to.deep.equal({ a: 1 })
+  })
+  it('updateSomeOn', () => {
+    let transforms = {
+      a: (x) => x + 5,
+      // iteratee support
+      c: 'd',
+      // nested support
+      e: {
+        f: (x) => x * 2,
+      },
+      // nested paths support
+      'e.h': (x) => x + 3,
+      // does not apply transforms if the keys are missing
+      notInObject: () => 'not there',
+    }
+    let input = {
+      a: 1,
+      b: 2,
+      c: { d: 1 },
+      e: { f: 1, g: 2, h: 3 },
+    }
+    let output = F.updateSomeOn(transforms, input)
+    // Handle all cases
+    expect(output).to.deep.equal({ a: 6, b: 2, c: 1, e: { f: 2, g: 2, h: 6 } })
+    // Mutable
+    expect(output).to.deep.equal(input)
+    // Handle null transforms
+    expect(F.updateSomeOn(null, { a: 1 })).to.deep.equal({ a: 1 })
+  })
+  it('updateAllOn', () => {
+    let transforms = {
+      a: (x) => x + 5,
+      // iteratee support
+      c: 'd',
+      // nested support
+      e: {
+        f: (x) => x * 2,
+      },
+      // nested paths support
+      'e.h': (x) => x + 3,
+      // applies transforms even if the keys are missing
+      notInObject: () => 'not there',
+    }
+    let input = {
+      a: 1,
+      b: 2,
+      c: { d: 1 },
+      e: { f: 1, g: 2, h: 3 },
+    }
+    let output = F.updateAllOn(transforms, input)
+    // Handle all cases
+    expect(output).to.deep.equal({
+      a: 6,
+      b: 2,
+      c: 1,
+      e: { f: 2, g: 2, h: 6 },
+      notInObject: 'not there',
+    })
+    // Mutable
+    expect(output).to.deep.equal(input)
+    // Handle null transforms
+    expect(F.updateAllOn(null, { a: 1 })).to.deep.equal({ a: 1 })
+  })
 })

--- a/test/objects.spec.js
+++ b/test/objects.spec.js
@@ -930,4 +930,24 @@ describe('Object Functions', () => {
     // Handle null transforms
     expect(F.updateAllPathsOn(null, { a: 1 })).to.deep.equal({ a: 1 })
   })
+  it('matchesBy', () => {
+    // support both values and comparator functions
+    const test = F.matchesBy({
+      a: (x) => x > 1,
+      b: (x) => x == 2,
+      c: 4,
+    })
+    expect(test({ a: 3, b: 2, c: 4 })).to.equal(true)
+    expect(test({ a: 3, b: 4, c: 4 })).to.equal(false)
+  })
+  it('matchesBySome', () => {
+    // support both values and comparator functions
+    const test = F.matchesBySome({
+      a: (x) => x > 1,
+      b: (x) => x == 5,
+      c: 4,
+    })
+    expect(test({ a: 3, b: 2, c: 4 })).to.equal(true)
+    expect(test({ a: 0, b: 2, c: 6 })).to.equal(false)
+  })
 })

--- a/test/objects.spec.js
+++ b/test/objects.spec.js
@@ -192,6 +192,33 @@ describe('Object Functions', () => {
     const new1 = F.renameProperty('c', 'b', o)
     expect(new1).to.deep.equal({ a: 1 })
   })
+  it('renamePropertyOn', () => {
+    const o = { a: 1, d: { e: 2 } }
+    const newO = F.renamePropertyOn('a', 'b', o)
+    expect(newO).to.deep.equal(o)
+    expect(newO).to.deep.equal({ b: 1, d: { e: 2 } })
+
+    // Does not set target property if source property does not exist
+    const new1 = F.renamePropertyOn('c', 'b', o)
+    expect(new1).to.deep.equal({ b: 1, d: { e: 2 } })
+
+    // Nested Case
+    F.renamePropertyOn('d.e', 'd.f', o)
+    expect(o).to.deep.equal({ b: 1, d: { f: 2 } })
+  })
+  it('unsetProperty', () => {
+    // Basic case
+    let basic = { a: 1, b: 2, c: 3 }
+    let a = F.unsetProperty('a', basic)
+    expect(a).to.equal(1)
+    expect(basic).to.deep.equal({ b: 2, c: 3 })
+
+    // Nested case
+    let nested = { a: 1, b: 2, c: 3, d: { e: 4, f: 5 } }
+    let e = F.unsetProperty('d.e', nested)
+    expect(e).to.equal(4)
+    expect(nested).to.deep.equal({ a: 1, b: 2, c: 3, d: { f: 5 } })
+  })
   it('matchesSignature', () => {
     expect(F.matchesSignature([], 0)).to.be.false
     expect(F.matchesSignature([], '')).to.be.false

--- a/test/objects.spec.js
+++ b/test/objects.spec.js
@@ -786,7 +786,7 @@ describe('Object Functions', () => {
     let target = { a: 1, b: 2 }
     let output = F.updateOwn('a', (x) => x + 1, target)
     expect(output).to.deep.equal({ a: 2, b: 2 })
-    
+
     // Does note mutate
     expect(output).not.to.deep.equal(target)
 
@@ -798,7 +798,7 @@ describe('Object Functions', () => {
     let target = { a: 1, b: 2 }
     let output = F.updateOwnOn('a', (x) => x + 1, target)
     expect(output).to.deep.equal({ a: 2, b: 2 })
-    
+
     // Mutates
     expect(output).to.deep.equal(target)
 

--- a/test/objects.spec.js
+++ b/test/objects.spec.js
@@ -782,31 +782,31 @@ describe('Object Functions', () => {
 
     expect(F.firstCommonKey(providers, schema)).to.equal('elasticsearch')
   })
-  it('updateOwn', () => {
+  it('updateIfExists', () => {
     let target = { a: 1, b: 2 }
-    let output = F.updateOwn('a', (x) => x + 1, target)
+    let output = F.updateIfExists('a', (x) => x + 1, target)
     expect(output).to.deep.equal({ a: 2, b: 2 })
 
     // Does note mutate
     expect(output).not.to.deep.equal(target)
 
     // Does not run for missing keys
-    let missingCase = F.updateOwn('c', (x) => x + 1, { a: 1, b: 2 })
+    let missingCase = F.updateIfExists('c', (x) => x + 1, { a: 1, b: 2 })
     expect(missingCase).to.deep.equal({ a: 1, b: 2 })
   })
-  it('updateOwnOn', () => {
+  it('updateIfExistsOn', () => {
     let target = { a: 1, b: 2 }
-    let output = F.updateOwnOn('a', (x) => x + 1, target)
+    let output = F.updateIfExistsOn('a', (x) => x + 1, target)
     expect(output).to.deep.equal({ a: 2, b: 2 })
 
     // Mutates
     expect(output).to.deep.equal(target)
 
     // Does not run for missing keys
-    let missingCase = F.updateOwnOn('c', (x) => x + 1, { a: 1, b: 2 })
+    let missingCase = F.updateIfExistsOn('c', (x) => x + 1, { a: 1, b: 2 })
     expect(missingCase).to.deep.equal({ a: 1, b: 2 })
   })
-  it('updateSome', () => {
+  it('updatePaths', () => {
     let transforms = {
       a: (x) => x + 5,
       // iteratee support
@@ -826,15 +826,15 @@ describe('Object Functions', () => {
       c: { d: 1 },
       e: { f: 1, g: 2, h: 3 },
     }
-    let output = F.updateSome(transforms, input)
+    let output = F.updatePaths(transforms, input)
     // Handle all cases
     expect(output).to.deep.equal({ a: 6, b: 2, c: 1, e: { f: 2, g: 2, h: 6 } })
     // Immutable
     expect(output).not.to.deep.equal(input)
     // Handle null transforms
-    expect(F.updateSome(null, { a: 1 })).to.deep.equal({ a: 1 })
+    expect(F.updatePaths(null, { a: 1 })).to.deep.equal({ a: 1 })
   })
-  it('updateAll', () => {
+  it('updateAllPaths', () => {
     let transforms = {
       a: (x) => x + 5,
       // iteratee support
@@ -854,7 +854,7 @@ describe('Object Functions', () => {
       c: { d: 1 },
       e: { f: 1, g: 2, h: 3 },
     }
-    let output = F.updateAll(transforms, input)
+    let output = F.updateAllPaths(transforms, input)
     // Handle all cases
     expect(output).to.deep.equal({
       a: 6,
@@ -866,9 +866,9 @@ describe('Object Functions', () => {
     // Immutable
     expect(output).not.to.deep.equal(input)
     // Handle null transforms
-    expect(F.updateAll(null, { a: 1 })).to.deep.equal({ a: 1 })
+    expect(F.updateAllPaths(null, { a: 1 })).to.deep.equal({ a: 1 })
   })
-  it('updateSomeOn', () => {
+  it('updatePathsOn', () => {
     let transforms = {
       a: (x) => x + 5,
       // iteratee support
@@ -888,15 +888,15 @@ describe('Object Functions', () => {
       c: { d: 1 },
       e: { f: 1, g: 2, h: 3 },
     }
-    let output = F.updateSomeOn(transforms, input)
+    let output = F.updatePathsOn(transforms, input)
     // Handle all cases
     expect(output).to.deep.equal({ a: 6, b: 2, c: 1, e: { f: 2, g: 2, h: 6 } })
     // Mutable
     expect(output).to.deep.equal(input)
     // Handle null transforms
-    expect(F.updateSomeOn(null, { a: 1 })).to.deep.equal({ a: 1 })
+    expect(F.updatePathsOn(null, { a: 1 })).to.deep.equal({ a: 1 })
   })
-  it('updateAllOn', () => {
+  it('updateAllPathsOn', () => {
     let transforms = {
       a: (x) => x + 5,
       // iteratee support
@@ -916,7 +916,7 @@ describe('Object Functions', () => {
       c: { d: 1 },
       e: { f: 1, g: 2, h: 3 },
     }
-    let output = F.updateAllOn(transforms, input)
+    let output = F.updateAllPathsOn(transforms, input)
     // Handle all cases
     expect(output).to.deep.equal({
       a: 6,
@@ -928,6 +928,6 @@ describe('Object Functions', () => {
     // Mutable
     expect(output).to.deep.equal(input)
     // Handle null transforms
-    expect(F.updateAllOn(null, { a: 1 })).to.deep.equal({ a: 1 })
+    expect(F.updateAllPathsOn(null, { a: 1 })).to.deep.equal({ a: 1 })
   })
 })

--- a/test/string.spec.js
+++ b/test/string.spec.js
@@ -150,4 +150,8 @@ describe('String Functions', () => {
     expect(F.uniqueString(undefined)('test')).to.be.a('string')
     expect(F.uniqueString()('test')).to.be.a('string')
   })
+  it('crunchWhitespace', () => {
+    let input = '     space      \n\n\n  \t\t   everywhere    '
+    expect(F.crunchWhitespace(input)).to.equal('space everywhere')
+  })
 })


### PR DESCRIPTION
- Add `renamePropertyOn`, `unsetProperty`
- Add `updateOwn`, `updateOwnOn`, `updateSome`, `updateSomeOn`, `updateAll`, `updateAllOn`
- Add `crunchWhitespace`
- Export `writeTreeNode`
- Add `chunkByValue`
- Pass indexes to `arrayToObject`
- Add `omitByIndexed` conversion

Also begin adding `@since` and `@type` in jsdoc (preparing for proper TS typing:)