### PR TITLE
Fixed cascade, was returning undefined when it should of returned 0

### DIFF
--- a/src/object.js
+++ b/src/object.js
@@ -228,12 +228,18 @@ export let aliasIn = _.curry((x, prop) => _.getOr(prop, prop, x))
 /**
  * A `_.get` that takes an array of paths (or functions to return values) and returns the value at the first path that matches. Similar to `_.overSome`, but returns the first result that matches instead of just truthy (and supports a default value)
  */
-export let cascade = _.curryN(2, (paths, obj, defaultValue) =>
-  _.flow(
-    findApply((x) => x && _.iteratee(x)(obj)),
-    _.defaultTo(defaultValue)
-  )(paths)
-)
+export let cascade = (paths, obj, defaultValue) =>  _.reduce(
+  (acc, path) => {
+    if (_.isFunction(path)) {
+      const r = path(obj);
+      return r ? _.identity(r) : acc;
+    }
+    const o = _.get(path, obj);
+    return _.isUndefined(o) ? acc : _.identity(o);
+  },
+  defaultValue,
+  paths
+);
 
 /**
  * Flipped cascade

--- a/test/objects.spec.js
+++ b/test/objects.spec.js
@@ -263,6 +263,7 @@ describe('Object Functions', () => {
     expect(F.cascade(['x', 'c'], { a: 1, y: 2 }, 2)).to.equal(2)
     expect(F.cascade(['x', (x) => x.y], { a: 1, y: 2 })).to.equal(2)
     expect(F.cascade(['x', 'y'], { a: 1, x: null, y: 2 })).to.equal(2)
+    expect(F.cascade(['z'], { z: 0 })).to.equal(0)
   })
   it('cascadeIn', () => {
     expect(F.cascadeIn({ a: 1, y: 2 }, ['x', 'y'])).to.equal(2)


### PR DESCRIPTION
This is a fix to cascade

const c = cascade(['z'], { z: 0 })
c is now 0 instead of undefined
